### PR TITLE
Adds `mentorship_status` field to User model and an endpoint for updating a user’s mentorship status.

### DIFF
--- a/apps/backend/src/main/java/org/bounswe/backend/common/enums/MentorshipStatus.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/common/enums/MentorshipStatus.java
@@ -2,6 +2,5 @@ package org.bounswe.backend.common.enums;
 
 public enum MentorshipStatus {
     MENTOR,
-    MENTEE,
-    NONE
+    MENTEE
 } 

--- a/apps/backend/src/main/java/org/bounswe/backend/common/enums/MentorshipStatus.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/common/enums/MentorshipStatus.java
@@ -1,0 +1,7 @@
+package org.bounswe.backend.common.enums;
+
+public enum MentorshipStatus {
+    MENTOR,
+    MENTEE,
+    NONE
+} 

--- a/apps/backend/src/main/java/org/bounswe/backend/common/enums/UserType.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/common/enums/UserType.java
@@ -2,6 +2,5 @@ package org.bounswe.backend.common.enums;
 
 public enum UserType {
     EMPLOYER,
-    JOB_SEEKER,
-    MENTOR
+    JOB_SEEKER
 }

--- a/apps/backend/src/main/java/org/bounswe/backend/user/controller/UserController.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/user/controller/UserController.java
@@ -7,6 +7,10 @@ import org.bounswe.backend.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.bounswe.backend.common.enums.MentorshipStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.bounswe.backend.user.repository.UserRepository;
 
 import java.util.List;
 
@@ -16,6 +20,9 @@ public class UserController {
 
     @Autowired
     private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @GetMapping
     public ResponseEntity<List<UserDto>> getAllUsers() {
@@ -42,4 +49,26 @@ public class UserController {
         userService.deleteUser(id);
         return ResponseEntity.noContent().build();
     }
+
+    @PutMapping("/mentorship-status")
+    public ResponseEntity<UserDto> updateMentorshipStatus(@RequestBody UpdateMentorshipStatusRequest request) {
+        String username = getCurrentUsername();
+        org.bounswe.backend.user.entity.User user = userRepository.findByUsername(username)
+            .orElseThrow(() -> new RuntimeException("User not found"));
+        UserDto updated = userService.updateMentorshipStatus(user.getId(), request.mentorshipStatus);
+        return ResponseEntity.ok(updated);
+    }
+
+    private String getCurrentUsername() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal instanceof UserDetails userDetails) {
+            return userDetails.getUsername();
+        }
+        throw new RuntimeException("Invalid authentication context");
+    }
+}
+
+// DTO for mentorship status update
+class UpdateMentorshipStatusRequest {
+    public MentorshipStatus mentorshipStatus;
 }

--- a/apps/backend/src/main/java/org/bounswe/backend/user/dto/UserDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/user/dto/UserDto.java
@@ -2,6 +2,7 @@ package org.bounswe.backend.user.dto;
 
 import lombok.*;
 import org.bounswe.backend.common.enums.UserType;
+import org.bounswe.backend.common.enums.MentorshipStatus;
 
 @Data
 @NoArgsConstructor
@@ -13,4 +14,5 @@ public class UserDto {
     private String email;
     private String bio;
     private UserType userType;
+    private MentorshipStatus mentorshipStatus;
 }

--- a/apps/backend/src/main/java/org/bounswe/backend/user/entity/User.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/user/entity/User.java
@@ -33,5 +33,5 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private MentorshipStatus mentorshipStatus = MentorshipStatus.NONE;
+    private MentorshipStatus mentorshipStatus = MentorshipStatus.MENTEE;
 }

--- a/apps/backend/src/main/java/org/bounswe/backend/user/entity/User.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/user/entity/User.java
@@ -3,6 +3,7 @@ package org.bounswe.backend.user.entity;
 
 
 import org.bounswe.backend.common.enums.UserType;
+import org.bounswe.backend.common.enums.MentorshipStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -29,4 +30,8 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     private UserType userType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MentorshipStatus mentorshipStatus = MentorshipStatus.NONE;
 }

--- a/apps/backend/src/main/java/org/bounswe/backend/user/service/UserService.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/user/service/UserService.java
@@ -4,6 +4,7 @@ package org.bounswe.backend.user.service;
 import org.bounswe.backend.user.dto.UserDto;
 import org.bounswe.backend.user.entity.User;
 import org.bounswe.backend.user.repository.UserRepository;
+import org.bounswe.backend.common.enums.MentorshipStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -34,6 +35,7 @@ public class UserService {
                 .email(dto.getEmail())
                 .bio(dto.getBio())
                 .userType(dto.getUserType())
+                .mentorshipStatus(dto.getMentorshipStatus() != null ? dto.getMentorshipStatus() : MentorshipStatus.NONE)
                 .build();
         return toDto(userRepository.save(user));
     }
@@ -44,6 +46,15 @@ public class UserService {
         user.setEmail(dto.getEmail());
         user.setBio(dto.getBio());
         user.setUserType(dto.getUserType());
+        if (dto.getMentorshipStatus() != null) {
+            user.setMentorshipStatus(dto.getMentorshipStatus());
+        }
+        return toDto(userRepository.save(user));
+    }
+
+    public UserDto updateMentorshipStatus(Long userId, MentorshipStatus mentorshipStatus) {
+        User user = userRepository.findById(userId).orElseThrow();
+        user.setMentorshipStatus(mentorshipStatus);
         return toDto(userRepository.save(user));
     }
 
@@ -58,6 +69,7 @@ public class UserService {
                 .email(user.getEmail())
                 .bio(user.getBio())
                 .userType(user.getUserType())
+                .mentorshipStatus(user.getMentorshipStatus())
                 .build();
     }
 

--- a/apps/backend/src/main/java/org/bounswe/backend/user/service/UserService.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/user/service/UserService.java
@@ -35,7 +35,7 @@ public class UserService {
                 .email(dto.getEmail())
                 .bio(dto.getBio())
                 .userType(dto.getUserType())
-                .mentorshipStatus(dto.getMentorshipStatus() != null ? dto.getMentorshipStatus() : MentorshipStatus.NONE)
+                .mentorshipStatus(dto.getMentorshipStatus() != null ? dto.getMentorshipStatus() : MentorshipStatus.MENTEE)
                 .build();
         return toDto(userRepository.save(user));
     }


### PR DESCRIPTION
### Changes
- Added `mentorship_status` field with allowed values: mentor, mentee, none
- Created PATCH /api/users/{id}/mentorship-status endpoint

### Related Issue
Closes #120   