### PR TITLE
Feat/profile api

### DIFF
--- a/apps/backend/src/main/java/org/bounswe/backend/education/entity/Education.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/education/entity/Education.java
@@ -1,0 +1,37 @@
+package org.bounswe.backend.education.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.bounswe.backend.user.entity.User;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString(exclude = "user")
+@EqualsAndHashCode(exclude = "user")
+@Table(name = "education")
+public class Education {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String school;
+
+    private String degree;
+
+    private String field;
+
+    @Column(name = "start_date")
+    private String startDate;
+
+    @Column(name = "end_date")
+    private String endDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/controller/ProfileController.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/controller/ProfileController.java
@@ -55,23 +55,46 @@ public class ProfileController {
 
     @PatchMapping("/profile/{userId}/skills")
     public ResponseEntity<ProfileDto> updateSkills(@PathVariable Long userId,
-                                                   @RequestBody List<String> skills) {
+                                                   @RequestBody SkillUpdateRequestDto request) {
         User user = getCurrentUser();
         if (!user.getId().equals(userId)) {
-            return ResponseEntity.status(403).build(); // Forbidden
+            return ResponseEntity.status(403).build();
         }
-        return ResponseEntity.ok(profileService.updateSkills(userId, skills));
+        return ResponseEntity.ok(profileService.updateSkills(userId, request.getSkills()));
     }
 
     @PatchMapping("/profile/{userId}/interests")
-    public ResponseEntity<ProfileDto> updateInterests(@PathVariable Long userId, @RequestBody List<String> interests) {
+    public ResponseEntity<ProfileDto> updateInterests(@PathVariable Long userId,
+                                                      @RequestBody InterestUpdateRequestDto request) {
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build();
+        }
+        return ResponseEntity.ok(profileService.updateInterests(userId, request.getInterests()));
+    }
 
+
+    @PostMapping("/profile/{userId}/profile-picture")
+    public ResponseEntity<ProfileDto> updateProfilePicture(@PathVariable Long userId,
+                                                           @Valid @RequestBody UpdateProfilePictureRequestDto dto) {
         User user = getCurrentUser();
         if (!user.getId().equals(userId)) {
             return ResponseEntity.status(403).build(); // Forbidden
         }
-        return ResponseEntity.ok(profileService.updateInterests(userId, interests));
+        return ResponseEntity.ok(profileService.updateProfilePicture(userId, dto.getProfilePicture()));
     }
+
+
+    @DeleteMapping("/profile/{userId}/profile-picture")
+    public ResponseEntity<ProfileDto> deleteProfilePicture(@PathVariable Long userId) {
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build(); // Forbidden
+        }
+        return ResponseEntity.ok(profileService.deleteProfilePicture(userId));
+    }
+
+
 
 
 

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/controller/ProfileController.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/controller/ProfileController.java
@@ -169,8 +169,33 @@ public class ProfileController {
     }
 
 
+    @GetMapping("/profile/{userId}/badges")
+    public ResponseEntity<List<BadgeDto>> getBadges(@PathVariable Long userId) {
+        return ResponseEntity.ok(profileService.getBadgesByUserId(userId));
+    }
 
 
+    @PostMapping("/profile/{userId}/badges")
+    public ResponseEntity<BadgeDto> addBadge(@PathVariable Long userId,
+                                             @Valid @RequestBody CreateBadgeRequestDto dto) {
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build(); // Forbidden
+        }
+        return ResponseEntity.ok(profileService.addBadge(userId, dto));
+    }
+
+
+    @DeleteMapping("/profile/{userId}/badges/{badgeId}")
+    public ResponseEntity<Void> deleteBadge(@PathVariable Long userId,
+                                            @PathVariable Long badgeId) {
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build(); // Forbidden
+        }
+        profileService.deleteBadge(userId, badgeId);
+        return ResponseEntity.noContent().build();
+    }
 
 
 

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/controller/ProfileController.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/controller/ProfileController.java
@@ -86,12 +86,13 @@ public class ProfileController {
 
 
     @DeleteMapping("/profile/{userId}/profile-picture")
-    public ResponseEntity<ProfileDto> deleteProfilePicture(@PathVariable Long userId) {
+    public ResponseEntity<Void> deleteProfilePicture(@PathVariable Long userId) {
         User user = getCurrentUser();
         if (!user.getId().equals(userId)) {
             return ResponseEntity.status(403).build(); // Forbidden
         }
-        return ResponseEntity.ok(profileService.deleteProfilePicture(userId));
+        profileService.deleteProfilePicture(userId);
+        return ResponseEntity.noContent().build(); // 204 No Content
     }
 
 
@@ -111,6 +112,29 @@ public class ProfileController {
         ExperienceDto createdExperience = profileService.addExperience(userId, dto);
         return ResponseEntity.ok(createdExperience);
     }
+
+    @PutMapping("/profile/{userId}/experience/{expId}")
+    public ResponseEntity<ExperienceDto> updateExperience(@PathVariable Long userId,
+                                                          @PathVariable Long expId,
+                                                          @RequestBody UpdateExperienceRequestDto dto) {
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build(); // Forbidden
+        }
+        return ResponseEntity.ok(profileService.updateExperience(userId, expId, dto));
+    }
+
+    @DeleteMapping("/profile/{userId}/experience/{expId}")
+    public ResponseEntity<Void> deleteExperience(@PathVariable Long userId, @PathVariable Long expId) {
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build(); // Forbidden
+        }
+        profileService.deleteExperience(userId, expId);
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+
 
 
 

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/controller/ProfileController.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/controller/ProfileController.java
@@ -99,6 +99,41 @@ public class ProfileController {
 
 
 
+    @PostMapping("/profile/{userId}/education")
+    public ResponseEntity<EducationDto> addEducation(@PathVariable Long userId,
+                                                     @Valid @RequestBody CreateEducationRequestDto dto) {
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build(); // Forbidden
+        }
+        return ResponseEntity.ok(profileService.addEducation(userId, dto));
+    }
+
+
+    @PutMapping("/profile/{userId}/education/{eduId}")
+    public ResponseEntity<EducationDto> updateEducation(@PathVariable Long userId,
+                                                        @PathVariable Long eduId,
+                                                        @RequestBody UpdateEducationRequestDto dto) {
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build();
+        }
+        return ResponseEntity.ok(profileService.updateEducation(userId, eduId, dto));
+    }
+
+
+    @DeleteMapping("/profile/{userId}/education/{eduId}")
+    public ResponseEntity<Void> deleteEducation(@PathVariable Long userId,
+                                                @PathVariable Long eduId) {
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build(); // Forbidden
+        }
+        profileService.deleteEducation(userId, eduId);
+        return ResponseEntity.noContent().build();
+    }
+
+
 
 
 
@@ -109,8 +144,7 @@ public class ProfileController {
         if (!user.getId().equals(userId)) {
             return ResponseEntity.status(403).build(); // Forbidden
         }
-        ExperienceDto createdExperience = profileService.addExperience(userId, dto);
-        return ResponseEntity.ok(createdExperience);
+        return ResponseEntity.ok(profileService.addExperience(userId, dto));
     }
 
     @PutMapping("/profile/{userId}/experience/{expId}")

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/controller/ProfileController.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/controller/ProfileController.java
@@ -1,0 +1,82 @@
+package org.bounswe.backend.profile.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.bounswe.backend.profile.dto.*;
+import org.bounswe.backend.profile.service.ProfileService;
+import org.bounswe.backend.user.entity.User;
+import org.bounswe.backend.user.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@Tag(name = "Profile", description = "User profile endpoints")
+public class ProfileController {
+
+    private final ProfileService profileService;
+    private final UserRepository userRepository;
+
+    public ProfileController(ProfileService profileService, UserRepository userRepository) {
+        this.profileService = profileService;
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<FullProfileDto> getMyProfile() {
+        User user = getCurrentUser();
+        return ResponseEntity.ok(profileService.getProfileByUserId(user.getId()));
+    }
+
+    @GetMapping("profile/{userId}")
+    public ResponseEntity<FullProfileDto> getProfileByUserId(@PathVariable Long userId) {
+        return ResponseEntity.ok(profileService.getProfileByUserId(userId));
+    }
+
+    @PostMapping("/profile")
+    public ResponseEntity<ProfileDto> createProfile(@Valid @RequestBody CreateProfileRequestDto dto) {
+        User user = getCurrentUser();
+        return ResponseEntity.ok(profileService.createProfile(user.getId(), dto));
+    }
+
+    @PatchMapping("/profile/{userId}")
+    public ResponseEntity<ProfileDto> updateProfile(@PathVariable Long userId,
+                                                    @Valid @RequestBody UpdateProfileRequestDto dto) {
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build(); // Forbidden
+        }
+        return ResponseEntity.ok(profileService.updateProfile(userId, dto));
+    }
+
+
+    @PostMapping("/profile/{userId}/experience")
+    public ResponseEntity<?> addExperience(@PathVariable Long userId,
+                                           @Valid @RequestBody CreateExperienceRequestDto dto) {
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build(); // Forbidden
+        }
+        return ResponseEntity.ok(profileService.addExperience(userId, dto));
+    }
+
+
+
+
+
+    private User getCurrentUser() {
+        String username = getCurrentUsername();
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+    }
+
+    private String getCurrentUsername() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal instanceof UserDetails userDetails) {
+            return userDetails.getUsername();
+        }
+        throw new RuntimeException("Invalid authentication context");
+    }
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/controller/ProfileController.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/controller/ProfileController.java
@@ -11,6 +11,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api")
 @Tag(name = "Profile", description = "User profile endpoints")
@@ -51,15 +53,40 @@ public class ProfileController {
         return ResponseEntity.ok(profileService.updateProfile(userId, dto));
     }
 
-
-    @PostMapping("/profile/{userId}/experience")
-    public ResponseEntity<?> addExperience(@PathVariable Long userId,
-                                           @Valid @RequestBody CreateExperienceRequestDto dto) {
+    @PatchMapping("/profile/{userId}/skills")
+    public ResponseEntity<ProfileDto> updateSkills(@PathVariable Long userId,
+                                                   @RequestBody List<String> skills) {
         User user = getCurrentUser();
         if (!user.getId().equals(userId)) {
             return ResponseEntity.status(403).build(); // Forbidden
         }
-        return ResponseEntity.ok(profileService.addExperience(userId, dto));
+        return ResponseEntity.ok(profileService.updateSkills(userId, skills));
+    }
+
+    @PatchMapping("/profile/{userId}/interests")
+    public ResponseEntity<ProfileDto> updateInterests(@PathVariable Long userId, @RequestBody List<String> interests) {
+
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build(); // Forbidden
+        }
+        return ResponseEntity.ok(profileService.updateInterests(userId, interests));
+    }
+
+
+
+
+
+
+    @PostMapping("/profile/{userId}/experience")
+    public ResponseEntity<ExperienceDto> addExperience(@PathVariable Long userId,
+                                                       @Valid @RequestBody CreateExperienceRequestDto dto) {
+        User user = getCurrentUser();
+        if (!user.getId().equals(userId)) {
+            return ResponseEntity.status(403).build(); // Forbidden
+        }
+        ExperienceDto createdExperience = profileService.addExperience(userId, dto);
+        return ResponseEntity.ok(createdExperience);
     }
 
 

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/BadgeDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/BadgeDto.java
@@ -1,0 +1,17 @@
+package org.bounswe.backend.profile.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BadgeDto {
+    private Long id;
+    private String name;
+    private String description;
+    private String icon;
+    private LocalDateTime earnedAt;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/CreateBadgeRequestDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/CreateBadgeRequestDto.java
@@ -1,0 +1,20 @@
+package org.bounswe.backend.profile.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateBadgeRequestDto {
+
+    @NotBlank(message = "Badge name is required")
+    private String name;
+
+    @NotBlank(message = "Badge description is required")
+    private String description;
+
+    @NotBlank(message = "Badge icon is required")
+    private String icon;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/CreateEducationRequestDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/CreateEducationRequestDto.java
@@ -1,0 +1,25 @@
+package org.bounswe.backend.profile.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateEducationRequestDto {
+
+    @NotBlank(message = "School is required")
+    private String school;
+
+    @NotBlank(message = "Degree is required")
+    private String degree;
+
+    @NotBlank(message = "Field of study is required")
+    private String field;
+
+    @NotBlank(message = "Start date is required")
+    private String startDate;
+
+    private String endDate; // Optional
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/CreateExperienceRequestDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/CreateExperienceRequestDto.java
@@ -1,0 +1,25 @@
+package org.bounswe.backend.profile.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateExperienceRequestDto {
+
+    @NotBlank(message = "Company is required")
+    private String company;
+
+    @NotBlank(message = "Position is required")
+    private String position;
+
+    @NotBlank(message = "Description is required")
+    private String description;
+
+    @NotBlank(message = "Start date is required")
+    private String startDate;
+
+    private String endDate; // Optional
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/CreateProfileRequestDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/CreateProfileRequestDto.java
@@ -1,7 +1,5 @@
 package org.bounswe.backend.profile.dto;
 
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.util.List;
@@ -11,24 +9,12 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class CreateProfileRequestDto {
-
-    @NotNull(message = "User ID is required")
-    private Long userId;
-
     private String fullName;
-
     private String phone;
-
     private String location;
-
     private String occupation;
-
-    @Size(max = 1000, message = "Bio must be at most 1000 characters")
     private String bio;
-
     private String profilePicture;
-
     private List<String> skills;
-
     private List<String> interests;
 }

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/CreateProfileRequestDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/CreateProfileRequestDto.java
@@ -1,0 +1,34 @@
+package org.bounswe.backend.profile.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateProfileRequestDto {
+
+    @NotNull(message = "User ID is required")
+    private Long userId;
+
+    private String fullName;
+
+    private String phone;
+
+    private String location;
+
+    private String occupation;
+
+    @Size(max = 1000, message = "Bio must be at most 1000 characters")
+    private String bio;
+
+    private String profilePicture;
+
+    private List<String> skills;
+
+    private List<String> interests;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/EducationDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/EducationDto.java
@@ -1,0 +1,16 @@
+package org.bounswe.backend.profile.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EducationDto {
+    private Long id;
+    private String school;
+    private String degree;
+    private String field;
+    private String startDate;
+    private String endDate;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/ExperienceDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/ExperienceDto.java
@@ -1,0 +1,16 @@
+package org.bounswe.backend.profile.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExperienceDto {
+    private Long id;
+    private String company;
+    private String position;
+    private String description;
+    private String startDate;
+    private String endDate;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/FullProfileDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/FullProfileDto.java
@@ -13,7 +13,6 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class FullProfileDto {
-    private UserDto user;
     private ProfileDto profile;
     private List<ExperienceDto> experience;
     private List<EducationDto> education;

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/FullProfileDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/FullProfileDto.java
@@ -1,0 +1,21 @@
+package org.bounswe.backend.profile.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.bounswe.backend.user.dto.UserDto;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FullProfileDto {
+    private UserDto user;
+    private ProfileDto profile;
+    private List<ExperienceDto> experience;
+    private List<EducationDto> education;
+    private List<BadgeDto> badges;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/InterestUpdateRequestDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/InterestUpdateRequestDto.java
@@ -1,0 +1,10 @@
+package org.bounswe.backend.profile.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class InterestUpdateRequestDto {
+    private List<String> interests;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/ProfileDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/ProfileDto.java
@@ -1,0 +1,32 @@
+package org.bounswe.backend.profile.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProfileDto {
+
+    private Long id;
+
+    private String fullName;
+
+    private String phone;
+
+    private String location;
+
+    private String occupation;
+
+    private String bio;
+
+    private String profilePicture;
+
+    private List<String> skills;
+
+    private List<String> interests;
+
+    private Long userId;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/SkillUpdateRequestDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/SkillUpdateRequestDto.java
@@ -1,0 +1,10 @@
+package org.bounswe.backend.profile.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class SkillUpdateRequestDto {
+    private List<String> skills;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/UpdateEducationRequestDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/UpdateEducationRequestDto.java
@@ -1,0 +1,15 @@
+package org.bounswe.backend.profile.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateEducationRequestDto {
+    private String school;
+    private String degree;
+    private String field;
+    private String startDate;
+    private String endDate;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/UpdateExperienceRequestDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/UpdateExperienceRequestDto.java
@@ -1,0 +1,15 @@
+package org.bounswe.backend.profile.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateExperienceRequestDto {
+    private String company;
+    private String position;
+    private String description;
+    private String startDate;
+    private String endDate;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/UpdateProfilePictureRequestDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/UpdateProfilePictureRequestDto.java
@@ -1,0 +1,11 @@
+package org.bounswe.backend.profile.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class UpdateProfilePictureRequestDto {
+
+    @NotBlank(message = "Profile picture URL must not be blank")
+    private String profilePicture;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/UpdateProfileRequestDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/UpdateProfileRequestDto.java
@@ -1,0 +1,30 @@
+package org.bounswe.backend.profile.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateProfileRequestDto {
+
+    private String fullName;
+
+    private String phone;
+
+    private String location;
+
+    private String occupation;
+
+    @Size(max = 1000, message = "Bio must be at most 1000 characters")
+    private String bio;
+
+    private String profilePicture;
+
+    private List<String> skills;
+
+    private List<String> interests;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/dto/UpdateProfileRequestDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/dto/UpdateProfileRequestDto.java
@@ -1,6 +1,5 @@
 package org.bounswe.backend.profile.dto;
 
-import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.util.List;
@@ -19,7 +18,6 @@ public class UpdateProfileRequestDto {
 
     private String occupation;
 
-    @Size(max = 1000, message = "Bio must be at most 1000 characters")
     private String bio;
 
     private String profilePicture;

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/entity/Education.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/entity/Education.java
@@ -1,4 +1,4 @@
-package org.bounswe.backend.education.entity;
+package org.bounswe.backend.profile.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/entity/Experience.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/entity/Experience.java
@@ -1,0 +1,37 @@
+package org.bounswe.backend.profile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.bounswe.backend.user.entity.User;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString(exclude = "user")
+@EqualsAndHashCode(exclude = "user")
+@Table(name = "experience")
+public class Experience {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String company;
+
+    private String position;
+
+    private String description;
+
+    @Column(name = "start_date")
+    private String startDate;
+
+    @Column(name = "end_date")
+    private String endDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/entity/Profile.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/entity/Profile.java
@@ -1,0 +1,49 @@
+package org.bounswe.backend.profile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.bounswe.backend.user.entity.User;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString(exclude = "user")
+@EqualsAndHashCode(exclude = "user")
+@Table(name = "profiles")
+public class Profile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String fullName;
+
+    private String phone;
+
+    private String location;
+
+    private String occupation;
+
+    private String bio;
+
+    private String profilePicture;
+
+    @ElementCollection
+    @CollectionTable(name = "profile_skills", joinColumns = @JoinColumn(name = "profile_id"))
+    @Column(name = "skill")
+    private List<String> skills;
+
+    @ElementCollection
+    @CollectionTable(name = "profile_interests", joinColumns = @JoinColumn(name = "profile_id"))
+    @Column(name = "interest")
+    private List<String> interests;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/entity/UserBadge.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/entity/UserBadge.java
@@ -1,4 +1,4 @@
-package org.bounswe.backend.userbadge.entity;
+package org.bounswe.backend.profile.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/repository/EducationRepository.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/repository/EducationRepository.java
@@ -1,0 +1,10 @@
+package org.bounswe.backend.profile.repository;
+
+import org.bounswe.backend.profile.entity.Education;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EducationRepository extends JpaRepository<Education, Long> {
+    List<Education> findByUserId(Long userId);
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/repository/ExperienceRepository.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/repository/ExperienceRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface ExperienceRepository extends JpaRepository<Experience, Long> {
     List<Experience> findByUserId(Long userId);
+
 }

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/repository/ExperienceRepository.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/repository/ExperienceRepository.java
@@ -1,0 +1,10 @@
+package org.bounswe.backend.profile.repository;
+
+import org.bounswe.backend.profile.entity.Experience;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ExperienceRepository extends JpaRepository<Experience, Long> {
+    List<Experience> findByUserId(Long userId);
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/repository/ProfileRepository.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/repository/ProfileRepository.java
@@ -1,0 +1,12 @@
+package org.bounswe.backend.profile.repository;
+
+import org.bounswe.backend.profile.entity.Profile;
+import org.bounswe.backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProfileRepository extends JpaRepository<Profile, Long> {
+    Optional<Profile> findByUser(User user);
+    Optional<Profile> findByUserId(Long userId);
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/repository/UserBadgeRepository.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/repository/UserBadgeRepository.java
@@ -1,0 +1,10 @@
+package org.bounswe.backend.profile.repository;
+
+import org.bounswe.backend.profile.entity.UserBadge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
+    List<UserBadge> findByUserId(Long userId);
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
@@ -1,0 +1,182 @@
+package org.bounswe.backend.profile.service;
+
+import lombok.RequiredArgsConstructor;
+import org.bounswe.backend.profile.dto.*;
+import org.bounswe.backend.profile.entity.*;
+import org.bounswe.backend.profile.repository.*;
+import org.bounswe.backend.user.dto.UserDto;
+import org.bounswe.backend.user.entity.User;
+import org.bounswe.backend.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+    private final UserRepository userRepository;
+    private final ProfileRepository profileRepository;
+    private final ExperienceRepository experienceRepository;
+    private final EducationRepository educationRepository;
+    private final UserBadgeRepository badgeRepository;
+
+    @Transactional(readOnly = true)
+    public FullProfileDto getProfileByUserId(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Profile profile = profileRepository.findByUserId(userId)
+                .orElseThrow(() -> new RuntimeException("Profile not found"));
+
+        List<ExperienceDto> experience = experienceRepository.findByUserId(userId)
+                .stream().map(this::toDto).collect(Collectors.toList());
+
+        List<EducationDto> education = educationRepository.findByUserId(userId)
+                .stream().map(this::toDto).collect(Collectors.toList());
+
+        List<BadgeDto> badges = badgeRepository.findByUserId(userId)
+                .stream().map(this::toDto).collect(Collectors.toList());
+
+        return FullProfileDto.builder()
+                .user(toDto(user))
+                .profile(toDto(profile))
+                .experience(experience)
+                .education(education)
+                .badges(badges)
+                .build();
+    }
+
+
+    @Transactional
+    public ProfileDto createProfile(Long userId, CreateProfileRequestDto dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // Check if profile already exists
+        if (profileRepository.findByUserId(userId).isPresent()) {
+            throw new RuntimeException("Profile already exists for this user");
+        }
+
+        Profile profile = Profile.builder()
+                .user(user)
+                .fullName(dto.getFullName())
+                .phone(dto.getPhone())
+                .location(dto.getLocation())
+                .occupation(dto.getOccupation())
+                .bio(dto.getBio())
+                .profilePicture(dto.getProfilePicture())
+                .skills(dto.getSkills())
+                .interests(dto.getInterests())
+                .build();
+
+        return toDto(profileRepository.save(profile));
+    }
+
+
+    @Transactional
+    public ProfileDto updateProfile(Long userId, UpdateProfileRequestDto dto) {
+        Profile profile = profileRepository.findByUserId(userId)
+                .orElseThrow(() -> new RuntimeException("Profile not found"));
+
+        if (dto.getFullName() != null) profile.setFullName(dto.getFullName());
+        if (dto.getPhone() != null) profile.setPhone(dto.getPhone());
+        if (dto.getLocation() != null) profile.setLocation(dto.getLocation());
+        if (dto.getOccupation() != null) profile.setOccupation(dto.getOccupation());
+        if (dto.getBio() != null) profile.setBio(dto.getBio());
+        if (dto.getProfilePicture() != null) profile.setProfilePicture(dto.getProfilePicture());
+        if (dto.getSkills() != null) profile.setSkills(dto.getSkills());
+        if (dto.getInterests() != null) profile.setInterests(dto.getInterests());
+
+        return toDto(profileRepository.save(profile));
+    }
+
+    @Transactional
+    public ExperienceDto addExperience(Long userId, CreateExperienceRequestDto dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Experience experience = Experience.builder()
+                .company(dto.getCompany())
+                .position(dto.getPosition())
+                .description(dto.getDescription())
+                .startDate(dto.getStartDate())
+                .endDate(dto.getEndDate())
+                .user(user)
+                .build();
+
+        return toDto(experienceRepository.save(experience));
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    private UserDto toDto(User user) {
+        return UserDto.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .bio(user.getBio())
+                .userType(user.getUserType())
+                .build();
+    }
+
+    private ProfileDto toDto(Profile profile) {
+        return ProfileDto.builder()
+                .id(profile.getId())
+                .fullName(profile.getFullName())
+                .phone(profile.getPhone())
+                .location(profile.getLocation())
+                .occupation(profile.getOccupation())
+                .bio(profile.getBio())
+                .profilePicture(profile.getProfilePicture())
+                .skills(profile.getSkills())
+                .interests(profile.getInterests())
+                .userId(profile.getUser().getId())
+                .build();
+    }
+
+    private ExperienceDto toDto(Experience exp) {
+        return ExperienceDto.builder()
+                .id(exp.getId())
+                .company(exp.getCompany())
+                .position(exp.getPosition())
+                .description(exp.getDescription())
+                .startDate(exp.getStartDate())
+                .endDate(exp.getEndDate())
+                .build();
+    }
+
+    private EducationDto toDto(Education edu) {
+        return EducationDto.builder()
+                .id(edu.getId())
+                .school(edu.getSchool())
+                .degree(edu.getDegree())
+                .field(edu.getField())
+                .startDate(edu.getStartDate())
+                .endDate(edu.getEndDate())
+                .build();
+    }
+
+    private BadgeDto toDto(UserBadge badge) {
+        return BadgeDto.builder()
+                .id(badge.getId())
+                .name(badge.getName())
+                .description(badge.getDescription())
+                .icon(badge.getIcon())
+                .earnedAt(badge.getEarnedAt())
+                .build();
+    }
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
@@ -165,6 +165,45 @@ public class ProfileService {
 
 
 
+    @Transactional(readOnly = true)
+    public List<BadgeDto> getBadgesByUserId(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        return badgeRepository.findByUserId(userId)
+                .stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+
+    @Transactional
+    public BadgeDto addBadge(Long userId, CreateBadgeRequestDto dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        UserBadge badge = UserBadge.builder()
+                .name(dto.getName())
+                .description(dto.getDescription())
+                .icon(dto.getIcon())
+                .earnedAt(java.time.LocalDateTime.now())
+                .user(user)
+                .build();
+
+        return toDto(badgeRepository.save(badge));
+    }
+
+    @Transactional
+    public void deleteBadge(Long userId, Long badgeId) {
+        UserBadge badge = badgeRepository.findById(badgeId)
+                .orElseThrow(() -> new RuntimeException("Badge not found"));
+
+        if (!badge.getUser().getId().equals(userId)) {
+            throw new RuntimeException("You are not authorized to delete this badge.");
+        }
+
+        badgeRepository.delete(badge);
+    }
 
 
 

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
@@ -115,6 +115,58 @@ public class ProfileService {
     }
 
 
+    @Transactional
+    public EducationDto addEducation(Long userId, CreateEducationRequestDto dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Education education = Education.builder()
+                .school(dto.getSchool())
+                .degree(dto.getDegree())
+                .field(dto.getField())
+                .startDate(dto.getStartDate())
+                .endDate(dto.getEndDate())
+                .user(user)
+                .build();
+
+        return toDto(educationRepository.save(education));
+    }
+
+
+    @Transactional
+    public EducationDto updateEducation(Long userId, Long eduId, UpdateEducationRequestDto dto) {
+        Education education = educationRepository.findById(eduId)
+                .orElseThrow(() -> new RuntimeException("Education not found"));
+
+        if (!education.getUser().getId().equals(userId)) {
+            throw new RuntimeException("Unauthorized update attempt");
+        }
+
+        if (dto.getSchool() != null) education.setSchool(dto.getSchool());
+        if (dto.getDegree() != null) education.setDegree(dto.getDegree());
+        if (dto.getField() != null) education.setField(dto.getField());
+        if (dto.getStartDate() != null) education.setStartDate(dto.getStartDate());
+        if (dto.getEndDate() != null) education.setEndDate(dto.getEndDate());
+
+        return toDto(educationRepository.save(education));
+    }
+
+    @Transactional
+    public void deleteEducation(Long userId, Long eduId) {
+        Education education = educationRepository.findById(eduId)
+                .orElseThrow(() -> new RuntimeException("Education not found"));
+
+        if (!education.getUser().getId().equals(userId)) {
+            throw new RuntimeException("Unauthorized delete attempt");
+        }
+
+        educationRepository.delete(education);
+    }
+
+
+
+
+
 
 
     @Transactional

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
@@ -134,6 +134,26 @@ public class ProfileService {
         return toDto(experienceRepository.save(experience));
     }
 
+    @Transactional
+    public ProfileDto updateProfilePicture(Long userId, String profilePicture) {
+        Profile profile = profileRepository.findByUserId(userId)
+                .orElseThrow(() -> new RuntimeException("Profile not found"));
+
+        profile.setProfilePicture(profilePicture);
+        return toDto(profileRepository.save(profile));
+    }
+
+    @Transactional
+    public ProfileDto deleteProfilePicture(Long userId) {
+        Profile profile = profileRepository.findByUserId(userId)
+                .orElseThrow(() -> new RuntimeException("Profile not found"));
+
+        profile.setProfilePicture(null);
+        return toDto(profileRepository.save(profile));
+    }
+
+
+
 
 
 

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
@@ -135,6 +135,39 @@ public class ProfileService {
     }
 
     @Transactional
+    public ExperienceDto updateExperience(Long userId, Long expId, UpdateExperienceRequestDto dto) {
+        Experience experience = experienceRepository.findById(expId)
+                .orElseThrow(() -> new RuntimeException("Experience not found"));
+
+        if (!experience.getUser().getId().equals(userId)) {
+            throw new RuntimeException("Unauthorized to update this experience");
+        }
+
+        if (dto.getCompany() != null) experience.setCompany(dto.getCompany());
+        if (dto.getPosition() != null) experience.setPosition(dto.getPosition());
+        if (dto.getDescription() != null) experience.setDescription(dto.getDescription());
+        if (dto.getStartDate() != null) experience.setStartDate(dto.getStartDate());
+        if (dto.getEndDate() != null) experience.setEndDate(dto.getEndDate());
+
+        return toDto(experienceRepository.save(experience));
+    }
+
+
+    @Transactional
+    public void deleteExperience(Long userId, Long expId) {
+        Experience experience = experienceRepository.findById(expId)
+                .orElseThrow(() -> new RuntimeException("Experience not found"));
+
+        if (!experience.getUser().getId().equals(userId)) {
+            throw new RuntimeException("Unauthorized to delete this experience");
+        }
+
+        experienceRepository.delete(experience);
+    }
+
+
+
+    @Transactional
     public ProfileDto updateProfilePicture(Long userId, String profilePicture) {
         Profile profile = profileRepository.findByUserId(userId)
                 .orElseThrow(() -> new RuntimeException("Profile not found"));

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.bounswe.backend.profile.dto.*;
 import org.bounswe.backend.profile.entity.*;
 import org.bounswe.backend.profile.repository.*;
-import org.bounswe.backend.user.dto.UserDto;
 import org.bounswe.backend.user.entity.User;
 import org.bounswe.backend.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -268,42 +267,18 @@ public class ProfileService {
     }
 
     @Transactional
-    public ProfileDto deleteProfilePicture(Long userId) {
+    public void deleteProfilePicture(Long userId) {
         Profile profile = profileRepository.findByUserId(userId)
                 .orElseThrow(() -> new RuntimeException("Profile not found"));
 
         profile.setProfilePicture(null);
-        return toDto(profileRepository.save(profile));
+        profileRepository.save(profile);
     }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    private UserDto toDto(User user) {
-        return UserDto.builder()
-                .id(user.getId())
-                .username(user.getUsername())
-                .email(user.getEmail())
-                .bio(user.getBio())
-                .userType(user.getUserType())
-                .build();
-    }
 
     private ProfileDto toDto(Profile profile) {
-        return ProfileDto.builder()
+        return ProfileDto.builder() 
                 .id(profile.getId())
                 .fullName(profile.getFullName())
                 .phone(profile.getPhone())

--- a/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/profile/service/ProfileService.java
@@ -40,7 +40,6 @@ public class ProfileService {
                 .stream().map(this::toDto).collect(Collectors.toList());
 
         return FullProfileDto.builder()
-                .user(toDto(user))
                 .profile(toDto(profile))
                 .experience(experience)
                 .education(education)
@@ -91,6 +90,32 @@ public class ProfileService {
 
         return toDto(profileRepository.save(profile));
     }
+
+
+    @Transactional
+    public ProfileDto updateSkills(Long userId, List<String> skills) {
+        Profile profile = profileRepository.findByUserId(userId)
+                .orElseThrow(() -> new RuntimeException("Profile not found"));
+
+        profile.setSkills(skills);
+        Profile updated = profileRepository.save(profile);
+
+        return toDto(updated);
+    }
+
+
+    @Transactional
+    public ProfileDto updateInterests(Long userId, List<String> interests) {
+        Profile profile = profileRepository.findByUserId(userId)
+                .orElseThrow(() -> new RuntimeException("Profile not found"));
+
+        profile.setInterests(interests);
+        Profile updated = profileRepository.save(profile);
+        return toDto(updated);
+    }
+
+
+
 
     @Transactional
     public ExperienceDto addExperience(Long userId, CreateExperienceRequestDto dto) {

--- a/apps/backend/src/main/java/org/bounswe/backend/userbadge/entity/UserBadge.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/userbadge/entity/UserBadge.java
@@ -1,0 +1,32 @@
+package org.bounswe.backend.userbadge.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.bounswe.backend.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "user_badges")
+public class UserBadge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String description;
+    private String icon;
+
+    @Column(name = "earned_at", nullable = false)
+    private LocalDateTime earnedAt;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+}


### PR DESCRIPTION
## 🧑‍💼 Profile Feature: User Profiles, Skills, Interests, Education, Experience & Badges

### Summary  
This PR implements the backend logic and REST API endpoints for managing user profiles. Users can create, view, update, and enrich their profiles with experiences, education history, skills, interests, and badges.

---

### ✅ Features Implemented

#### 👤 Profile  
- `GET /api/me`: Get current user's full profile  
- `GET /api/profile/{userId}`: Get any user's full profile  
- `POST /api/profile`: Create profile for current user  
- `PATCH /api/profile/{userId}`: Update profile attributes  
- `POST /api/profile/{userId}/profile-picture`: Update profile picture  
- `DELETE /api/profile/{userId}/profile-picture`: Delete profile picture  

#### 🛠️ Skills & Interests  
- `PATCH /api/profile/{userId}/skills`: Update skills  
- `PATCH /api/profile/{userId}/interests`: Update interests  

#### 🎓 Education  
- `POST /api/profile/{userId}/education`: Add education entry  
- `PUT /api/profile/{userId}/education/{eduId}`: Update education entry  
- `DELETE /api/profile/{userId}/education/{eduId}`: Delete education entry  

#### 💼 Experience  
- `POST /api/profile/{userId}/experience`: Add experience entry  
- `PUT /api/profile/{userId}/experience/{expId}`: Update experience entry  
- `DELETE /api/profile/{userId}/experience/{expId}`: Delete experience entry  

#### 🏅 Badges  
- `GET /api/profile/{userId}/badges`: List user badges  
- `POST /api/profile/{userId}/badges`: Add a badge  
- `DELETE /api/profile/{userId}/badges/{badgeId}`: Remove a badge  

---

### 🧪 Notes  
- All endpoints are secured and require authentication.  
- Authorization checks ensure users can only modify their own profile data.  
- Endpoints were tested using Postman.  
