### PR TITLE
Feat/121 job api filter backend

### DIFF
--- a/apps/backend/src/main/java/org/bounswe/backend/common/config/OpenApiConfig.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/common/config/OpenApiConfig.java
@@ -2,6 +2,8 @@ package org.bounswe.backend.common.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,10 +12,20 @@ public class OpenApiConfig {
 
     @Bean
     public OpenAPI baseOpenAPI() {
+        final String securitySchemeName = "bearerAuth";
+
         return new OpenAPI()
                 .info(new Info()
                         .title("Ethical JobBoard API")
                         .version("1.0.0")
-                        .description("REST API documentation with Swagger UI"));
+                        .description("REST API documentation with Swagger UI"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new io.swagger.v3.oas.models.Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
     }
 }

--- a/apps/backend/src/main/java/org/bounswe/backend/job/controller/JobPostController.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/job/controller/JobPostController.java
@@ -1,5 +1,7 @@
 package org.bounswe.backend.job.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import org.bounswe.backend.job.dto.JobPostDto;
 import org.bounswe.backend.job.service.JobPostService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,8 +23,26 @@ public class JobPostController {
     }
 
     @GetMapping
-    public ResponseEntity<List<JobPostDto>> getAll() {
-        return ResponseEntity.ok(service.getAll());
+    public ResponseEntity<List<JobPostDto>> getAll(
+            @Parameter(name = "title", description = "Job title prefix", in = ParameterIn.QUERY)
+            @RequestParam(required = false) String title,
+
+            @Parameter(name = "companyName", description = "Company name prefix", in = ParameterIn.QUERY)
+            @RequestParam(required = false) String companyName,
+
+            @Parameter(name = "ethicalTags", description = "List of ethical policy tags", in = ParameterIn.QUERY)
+            @RequestParam(required = false) List<String> ethicalTags,
+
+            @Parameter(name = "minSalary", description = "Minimum salary", in = ParameterIn.QUERY)
+            @RequestParam(required = false) Integer minSalary,
+
+            @Parameter(name = "maxSalary", description = "Maximum salary", in = ParameterIn.QUERY)
+            @RequestParam(required = false) Integer maxSalary,
+
+            @Parameter(name = "isRemote", description = "Whether the job is remote", in = ParameterIn.QUERY)
+            @RequestParam(required = false) Boolean isRemote
+    ) {
+        return ResponseEntity.ok(service.getFiltered(title, companyName, ethicalTags, minSalary, maxSalary, isRemote));
     }
 
     @GetMapping("/employer/{employerId}")

--- a/apps/backend/src/main/java/org/bounswe/backend/job/dto/JobPostDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/job/dto/JobPostDto.java
@@ -30,4 +30,8 @@ public class JobPostDto {
     private boolean remote;
 
     private String ethicalTags; // Optional
+
+    private Integer minSalary;
+
+    private Integer maxSalary;
 }

--- a/apps/backend/src/main/java/org/bounswe/backend/job/entity/JobPost.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/job/entity/JobPost.java
@@ -32,4 +32,8 @@ public class JobPost {
     private boolean remote;
 
     private String ethicalTags; // comma-separated for now (e.g. "open-source,remote-first")
+
+    private Integer minSalary;
+
+    private Integer maxSalary;
 }

--- a/apps/backend/src/main/java/org/bounswe/backend/job/repository/JobPostRepository.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/job/repository/JobPostRepository.java
@@ -2,10 +2,30 @@ package org.bounswe.backend.job.repository;
 
 import org.bounswe.backend.job.entity.JobPost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface JobPostRepository extends JpaRepository<JobPost, Long> {
 
     List<JobPost> findByEmployerId(Long employerId);
+
+    @Query(value = """
+    SELECT * FROM job_posts j
+    WHERE (:title IS NULL OR LOWER(CAST(j.title AS varchar)) LIKE LOWER(CONCAT(CAST(:title AS varchar), '%')))
+    AND (:company IS NULL OR LOWER(CAST(j.company AS varchar)) LIKE LOWER(CONCAT(CAST(:company AS varchar), '%')))
+    AND (:minSalary IS NULL OR CAST(j.min_salary AS integer) >= CAST(:minSalary AS integer))
+    AND (:maxSalary IS NULL OR CAST(j.max_salary AS integer) <= CAST(:maxSalary AS integer))
+    AND (:isRemote IS NULL OR CAST(j.remote AS boolean) = CAST(:isRemote AS boolean))
+    """, nativeQuery = true)
+    List<JobPost> findFiltered(
+            @Param("title") String title,
+            @Param("company") String company,
+            @Param("ethicalPolicies") List<String> ethicalPolicies,
+            @Param("minSalary") Integer minSalary,
+            @Param("maxSalary") Integer maxSalary,
+            @Param("isRemote") Boolean isRemote
+    );
+
 }

--- a/apps/backend/src/main/java/org/bounswe/backend/job/repository/JobPostRepository.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/job/repository/JobPostRepository.java
@@ -22,7 +22,6 @@ public interface JobPostRepository extends JpaRepository<JobPost, Long> {
     List<JobPost> findFiltered(
             @Param("title") String title,
             @Param("company") String company,
-            @Param("ethicalPolicies") List<String> ethicalPolicies,
             @Param("minSalary") Integer minSalary,
             @Param("maxSalary") Integer maxSalary,
             @Param("isRemote") Boolean isRemote

--- a/apps/backend/src/main/java/org/bounswe/backend/job/service/JobPostService.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/job/service/JobPostService.java
@@ -31,11 +31,14 @@ public class JobPostService {
     }
 
     public List<JobPostDto> getFiltered(String title, String companyName, List<String> ethicalTags, Integer minSalary, Integer maxSalary, Boolean isRemote) {
-        List<JobPost> jobs = jobPostRepository.findFiltered(title, companyName, ethicalTags, minSalary, maxSalary, isRemote);
+        List<JobPost> jobs = jobPostRepository.findFiltered(title, companyName, minSalary, maxSalary, isRemote);
         return jobs.stream()
                 .filter(j -> {
                     if (ethicalTags == null || ethicalTags.isEmpty()) return true;
                     for (String tag : ethicalTags) {
+                        System.out.println(tag);
+                        System.out.println(j.getEthicalTags());
+                        System.out.println(j.getEthicalTags().toLowerCase().contains(tag.toLowerCase()));
                         if (j.getEthicalTags().toLowerCase().contains(tag.toLowerCase())) return true;
                     }
                     return false;


### PR DESCRIPTION
## 📌 Description

This PR implements advanced filtering for job posts in the backend. It allows clients to filter job listings via query parameters such as title, company, salary range, ethical tags, and remote work preference.

In addition, `minSalary` and `maxSalary` fields are added to job post creation logic, and Bearer Token support is integrated into Swagger UI for easier testing of protected endpoints.

---

## ✅ Changes

### 🔍 Filtering Enhancements
- 🌐 Added support for filtering via:
  - `title` (prefix match)
  - `company` (prefix match)
  - `minSalary` / `maxSalary` (range)
  - `isRemote` (boolean)
  - `ethicalPolicies` (any-match on comma-separated tags)
- Replaced static JPQL query with dynamic native SQL

### 📦 Job Post Creation
- 🆕 Added `minSalary` and `maxSalary` to:
  - `JobPost` entity
  - `JobPostDto`
  - Job post creation flow (controller, service, and mapper)

### 🔐 Swagger UI Improvements
- Added Bearer Token authentication (`bearerAuth`) to Swagger UI via OpenAPI config
- You can now click "Authorize" and test endpoints with JWT tokens

---

## 🧪 How to Test

### ➕ Create Job Post
Use the following JSON in Swagger or Postman:

```json
{
  "title": "Mobile Developer",
  "description": "Build apps for ethical hiring.",
  "company": "EthicaTech",
  "location": "Remote",
  "remote": true,
  "ethicalTags": "fair_wage,diversity",
  "minSalary": 4500,
  "maxSalary": 7000
}
```

and test filters with postman or swagger.
