### PR TITLE
Feat/144 motivational quote backend

### DIFF
--- a/apps/backend/pom.xml
+++ b/apps/backend/pom.xml
@@ -85,6 +85,14 @@
             <version>0.11.5</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/apps/backend/src/main/java/org/bounswe/backend/BackendApplication.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/BackendApplication.java
@@ -4,7 +4,11 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableCaching
+@EnableScheduling
 @OpenAPIDefinition(info = @Info(title = "Ethical Job Board API", version = "1.0"))
 @SpringBootApplication
 public class BackendApplication {

--- a/apps/backend/src/main/java/org/bounswe/backend/common/config/CacheConfig.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/common/config/CacheConfig.java
@@ -1,0 +1,25 @@
+package org.bounswe.backend.common.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import java.time.Duration;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        Caffeine<Object, Object> caffeine = Caffeine.newBuilder()
+                .maximumSize(100)
+                .expireAfterWrite(Duration.ofDays(1));
+
+        return new CaffeineCacheManager("todayQuote") {{
+            setCaffeine(caffeine);
+        }};
+    }
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/common/config/RestTemplateConfig.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/common/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package org.bounswe.backend.common.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/common/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/common/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/swagger-resources/**",
-                                "/webjars/**"
+                                "/webjars/**",
+                                "/api/quote/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/apps/backend/src/main/java/org/bounswe/backend/external/controller/QuoteController.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/external/controller/QuoteController.java
@@ -1,0 +1,21 @@
+package org.bounswe.backend.external.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/quote")
+public class QuoteController {
+
+    private final QuoteService quoteService;
+
+    public QuoteController(QuoteService quoteService) {
+        this.quoteService = quoteService;
+    }
+
+    @GetMapping("/today")
+    public ResponseEntity<QuoteDto> getTodayQuote() {
+        return ResponseEntity.ok(quoteService.getTodayQuote());
+    }
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/external/controller/QuoteController.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/external/controller/QuoteController.java
@@ -1,5 +1,8 @@
 package org.bounswe.backend.external.controller;
 
+import org.bounswe.backend.external.service.QuoteService;
+import org.bounswe.backend.external.dto.QuoteDto;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/apps/backend/src/main/java/org/bounswe/backend/external/dto/QuoteDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/external/dto/QuoteDto.java
@@ -1,0 +1,18 @@
+package org.bounswe.backend.external.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuoteDto {
+    
+    private String quote;
+
+    private String author;
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/external/dto/QuoteDto.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/external/dto/QuoteDto.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class QuoteDto {
     
-    private String quote;
+    private String q;
 
-    private String author;
+    private String a;
 }

--- a/apps/backend/src/main/java/org/bounswe/backend/external/service/QuoteScheduler.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/external/service/QuoteScheduler.java
@@ -1,0 +1,20 @@
+package org.bounswe.backend.external.service;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QuoteScheduler {
+
+    private final QuoteService quoteService;
+
+    public QuoteScheduler(QuoteService quoteService) {
+        this.quoteService = quoteService;
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void scheduleQuoteUpdate() {
+        quoteService.evictCache();
+        quoteService.getTodayQuote();
+    }
+}

--- a/apps/backend/src/main/java/org/bounswe/backend/external/service/QuoteService.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/external/service/QuoteService.java
@@ -23,6 +23,7 @@ public class QuoteService {
         String url = quoteApiUrl + "today";
         ResponseEntity<QuoteDto[]> response = restTemplate.getForEntity(url, QuoteDto[].class);
         if (response.getStatusCode().is2xxSuccessful() && response.hasBody()) {
+            assert response.getBody() != null;
             return response.getBody()[0];
         }
         throw new RuntimeException("Failed to fetch quote");

--- a/apps/backend/src/main/java/org/bounswe/backend/external/service/QuoteService.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/external/service/QuoteService.java
@@ -1,0 +1,33 @@
+package org.bounswe.backend.external.service;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.ResponseEntity;
+import org.bounswe.backend.external.dto.QuoteDto;
+
+@Service
+public class QuoteService {
+
+    private final RestTemplate restTemplate;
+    private final String quoteApiUrl = "https://zenquotes.io/api/";
+
+    public QuoteService(RestTemplateBuilder builder) {
+        this.restTemplate = builder.build();
+    }
+
+    @Cacheable("todayQuote")
+    public QuoteDto getTodayQuote() {
+        String url = quoteApiUrl + "today";
+        ResponseEntity<QuoteDto[]> response = restTemplate.getForEntity(url, QuoteDto[].class);
+        if (response.getStatusCode().is2xxSuccessful() && response.hasBody()) {
+            return response.getBody()[0];
+        }
+        throw new RuntimeException("Failed to fetch quote");
+    }
+
+    @CacheEvict(value = "todayQuote", allEntries = true)
+    public void evictCache() {}
+}

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -10,6 +10,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  cache:
+    type: caffeine
+    caffeine:
+      spec: maximumSize=100,expireAfterWrite=1d
 
 server:
   port: 8080


### PR DESCRIPTION
## ✨ Feature: Daily Quote from ZenQuotes API

### 📌 Description

This PR adds a backend integration with the [ZenQuotes.io](https://zenquotes.io) API to fetch a motivational quote once per day. The quote is served from the `/api/quotes/daily` endpoint and is cached to avoid repeated external calls. A scheduled task refreshes the cached quote every midnight.

---

### ✅ Changes

- ➕ Created `QuoteDto` to represent the ZenQuotes API response.
- ➕ Added `QuoteController` with endpoint: `GET /api/quotes/daily`
- ➕ Implemented `QuoteService` with:
  - `getTodayQuote()` method annotated with `@Cacheable("todayQuote")`
  - `evictTodayQuoteCache()` method annotated with `@CacheEvict`
- ➕ Introduced `QuoteScheduler` with a scheduled task:
  - Runs at 00:00 every night
  - Evicts old cache and triggers re-fetch
- 🔧 Added `CacheConfig.java` with a `CaffeineCacheManager` bean
  - Configured 1-day TTL for `todayQuote` cache
- 🧱 Enabled `@EnableCaching` and `@EnableScheduling` in main class
- 📦 Dependencies:
  - Added `spring-boot-starter-cache`
  - Added `com.github.ben-manes.caffeine:caffeine`

---

### 📥 Example Response

```json
{
  "q": "Your limitation—it’s only your imagination.",
  "a": "ZenQuotes"
}
```

### 🧪 How to Test
- Start backend and hit GET /api/quote/today
- You should receive a quote
- Call it again → same quote (cached)
- Wait until midnight or call evictTodayQuoteCache() to refresh

### 📎 Related
Closes #144 
Docs: https://zenquotes.io/api