### PR TITLE
Add unit tests for CommentController endpoints

### DIFF
--- a/apps/backend/src/main/java/org/bounswe/backend/comment/controller/CommentController.java
+++ b/apps/backend/src/main/java/org/bounswe/backend/comment/controller/CommentController.java
@@ -53,7 +53,7 @@ public class CommentController {
 
 
 
-    private User getCurrentUser() {
+    User getCurrentUser() {
         String username = getCurrentUsername();
         return userRepository.findByUsername(username)
                 .orElseThrow(() -> new RuntimeException("User not found"));

--- a/apps/backend/src/test/java/org/bounswe/backend/comment/controller/CommentControllerTest.java
+++ b/apps/backend/src/test/java/org/bounswe/backend/comment/controller/CommentControllerTest.java
@@ -1,0 +1,93 @@
+package org.bounswe.backend.comment.controller;
+
+import org.bounswe.backend.comment.dto.CommentDto;
+import org.bounswe.backend.comment.dto.CreateCommentRequestDto;
+import org.bounswe.backend.comment.service.CommentService;
+import org.bounswe.backend.user.dto.UserDto;
+import org.bounswe.backend.user.entity.User;
+import org.junit.jupiter.api.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class CommentControllerTest {
+
+    @Mock
+    private CommentService commentService;
+
+    @InjectMocks
+    private CommentController commentController;
+
+    private AutoCloseable closeable;
+    private User mockUser;
+    private CommentController spiedController;
+    private final LocalDateTime fixedNow = LocalDateTime.of(2025, 5, 12, 12, 0);
+
+
+    @BeforeEach
+    void setUp() {
+        closeable = MockitoAnnotations.openMocks(this);
+
+        mockUser = User.builder().id(1L).username("john").email("john@example.com").build();
+
+        spiedController = spy(commentController);
+        doReturn(mockUser).when(spiedController).getCurrentUser();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    void reportComment_success() {
+        Long commentId = 1L;
+
+        ResponseEntity<Void> response = spiedController.reportComment(commentId);
+
+        assertEquals(200, response.getStatusCode().value());
+        verify(commentService).reportComment(commentId);
+    }
+
+    @Test
+    void updateComment_success() {
+        Long commentId = 2L;
+        CreateCommentRequestDto request = CreateCommentRequestDto.builder()
+                .body("Updated content")
+                .build();
+
+        CommentDto expected = CommentDto.builder()
+                .id(commentId)
+                .body("Updated content")
+                .createdAt(fixedNow)
+                .reported(false)
+                .author(UserDto.builder().id(1L).username("john").build())
+                .build();
+
+        when(commentService.updateComment(commentId, mockUser.getId(), request.getBody()))
+                .thenReturn(expected);
+
+        ResponseEntity<CommentDto> response = spiedController.updateComment(commentId, request);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertEquals(expected.getBody(), response.getBody().getBody());
+        verify(commentService).updateComment(commentId, mockUser.getId(), request.getBody());
+    }
+
+    @Test
+    void deleteComment_success() {
+        Long commentId = 3L;
+
+        ResponseEntity<Void> response = spiedController.deleteComment(commentId);
+
+        assertEquals(204, response.getStatusCode().value());
+        verify(commentService).deleteComment(commentId, mockUser.getId());
+    }
+}


### PR DESCRIPTION
# ✅ PR: Add Unit Tests for `CommentController`

## Summary
This pull request adds unit test coverage for key endpoints in the `CommentController` using JUnit and Mockito. It ensures that controller behavior is verified in isolation from the service and database layers.

---

## 🔍 Covered Endpoints

- `POST /api/comments/{commentId}/report` – Report a comment  
- `PATCH /api/comments/{commentId}` – Update a comment  
- `DELETE /api/comments/{commentId}` – Delete a comment  

---

## ✅ Test Details

- Uses `spy()` to override `getCurrentUser()` for simulating authenticated requests
- Asserts response status codes and response bodies
- Verifies that the appropriate service methods are called with correct parameters
- Uses a fixed timestamp (`LocalDateTime.of(2025, 5, 12, 12, 0)`) to ensure deterministic results

---



