### PR TITLE
Feat/tag recommendation forum

### DIFF
--- a/apps/mobile/lib/core/services/tag_recommendation_service.dart
+++ b/apps/mobile/lib/core/services/tag_recommendation_service.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class TagRecommendationService {
+  static Future<Map<String, dynamic>> fetchSuggestions(String title) async {
+    try {
+      final query = title.trim().split(RegExp(r'\s+')).join('+');
+      final url = 'https://api.datamuse.com/words?ml=$query&max=10';
+
+      final response = await http.get(Uri.parse(url));
+
+      if (response.statusCode == 200) {
+        final List data = json.decode(response.body);
+
+        final filtered = data
+            .where((item) =>
+        item['word'] != null &&
+            item['word'].toString().isNotEmpty &&
+            item['word'].toString().length <= 255)
+            .toList();
+
+        filtered.sort((a, b) => (b['score'] ?? 0).compareTo(a['score'] ?? 0));
+
+        final suggestions = filtered
+            .take(2)
+            .map<String>((item) => item['word'].toString().toUpperCase())
+            .toList();
+
+        if (suggestions.isEmpty) {
+          return {
+            'status': 'empty',
+            'message': 'Please add more detail to the title.',
+          };
+        }
+
+        return {
+          'status': 'success',
+          'suggestions': suggestions,
+        };
+      } else {
+        return {
+          'status': 'error',
+          'message': 'Suggestions cannot be created, please try again.',
+        };
+      }
+    } catch (e) {
+      return {
+        'status': 'error',
+        'message': 'Please check your connection, and try again.',
+      };
+    }
+  }
+}

--- a/apps/mobile/lib/features/forum/screens/forum_page.dart
+++ b/apps/mobile/lib/features/forum/screens/forum_page.dart
@@ -70,52 +70,55 @@ class _ForumPageState extends State<ForumPage> {
             else
               RefreshIndicator(
                 onRefresh: _loadThreads,
-                child: ListView.builder(
-                  padding: const EdgeInsets.only(bottom: 100),
-                  itemCount: _threads.length,
-                  itemBuilder: (_, i) {
-                    final t = _threads[i];
-                    return Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                      child: ThreadTile(
-                        thread: t,
-                        onTap: () async {
-                          final result = await Navigator.push(
-                            ctx,
-                            MaterialPageRoute(
-                              builder: (_) => ThreadDetailScreen(thread: t),
-                            ),
-                          );
-                          if (result is DiscussionThread) {
-                            setState(() {
-                              final index = _threads.indexWhere((thread) => thread.id == result.id);
-                              if (index != -1) {
-                                _threads[index] = result;
+                  child: Scrollbar(
+                    thumbVisibility: true,
+                    child: ListView.builder(
+                      padding: const EdgeInsets.only(bottom: 100),
+                      itemCount: _threads.length,
+                      itemBuilder: (_, i) {
+                        final t = _threads[i];
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                          child: ThreadTile(
+                            thread: t,
+                            onTap: () async {
+                              final result = await Navigator.push(
+                                ctx,
+                                MaterialPageRoute(
+                                  builder: (_) => ThreadDetailScreen(thread: t),
+                                ),
+                              );
+                              if (result is DiscussionThread) {
+                                setState(() {
+                                  final index = _threads.indexWhere((thread) => thread.id == result.id);
+                                  if (index != -1) {
+                                    _threads[index] = result;
+                                  }
+                                });
+                              } else if (result == 'deleted') {
+                                setState(() {
+                                  _threads.removeWhere((thread) => thread.id == t.id);
+                                });
                               }
-                            });
-                          } else if (result == 'deleted') {
-                            setState(() {
-                              _threads.removeWhere((thread) => thread.id == t.id);
-                            });
-                          }
-                        },
-                        onEdit: (updatedThread) {
-                          setState(() {
-                            final index = _threads.indexWhere((th) => th.id == updatedThread.id);
-                            if (index != -1) {
-                              _threads[index] = updatedThread;
-                            }
-                          });
-                        },
-                        onDelete: () {
-                          setState(() {
-                            _threads.removeWhere((th) => th.id == t.id);
-                          });
-                        },
-                      ),
-                    );
-                  },
-                ),
+                            },
+                            onEdit: (updatedThread) {
+                              setState(() {
+                                final index = _threads.indexWhere((th) => th.id == updatedThread.id);
+                                if (index != -1) {
+                                  _threads[index] = updatedThread;
+                                }
+                              });
+                            },
+                            onDelete: () {
+                              setState(() {
+                                _threads.removeWhere((th) => th.id == t.id);
+                              });
+                            },
+                          ),
+                        );
+                      },
+                    ),
+                  ),
               ),
           // Always show FAB
           Positioned(

--- a/apps/mobile/lib/features/forum/screens/forum_page.dart
+++ b/apps/mobile/lib/features/forum/screens/forum_page.dart
@@ -18,11 +18,123 @@ class _ForumPageState extends State<ForumPage> {
   List<DiscussionThread> _threads = [];
   bool _isLoading = true;
   String? _errorMessage;
+  List<String> _selectedTags = [];
+  List<String> _allTags = [];
 
   @override
   void initState() {
     super.initState();
     _loadThreads();
+    _loadTags();
+  }
+
+  Future<void> _loadTags() async {
+    try {
+      final tags = await ApiService(authProvider: context.read<AuthProvider>()).fetchDiscussionTags();
+      setState(() {
+        _allTags = tags;
+      });
+    } catch (e) {
+      debugPrint('Failed to load tags: $e');
+    }
+  }
+  void _showFilterModal() {
+    _loadTags();
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (context) {
+        List<String> tempSelected = List.from(_selectedTags);
+        String searchQuery = '';
+
+        return StatefulBuilder(
+          builder: (context, setModalState) {
+            final filteredTags = _allTags
+                .where((tag) => tag.toLowerCase().contains(searchQuery.toLowerCase()))
+                .toList();
+
+            return SizedBox(
+              height: MediaQuery.of(context).size.height * 0.7,
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: TextField(
+                      decoration: const InputDecoration(
+                        labelText: 'Search tags',
+                        prefixIcon: Icon(Icons.search),
+                      ),
+                      onChanged: (value) {
+                        setModalState(() => searchQuery = value);
+                      },
+                    ),
+                  ),
+                  const Divider(height: 1),
+                  Expanded(
+                    child: Scrollbar(
+                      thumbVisibility: true,
+                      child: SingleChildScrollView(
+                        padding: const EdgeInsets.all(16),
+                        child: Wrap(
+                          spacing: 8,
+                          runSpacing: 8,
+                          children: filteredTags.map((tag) {
+                            final isSelected = tempSelected.contains(tag);
+                            return FilterChip(
+                              label: Text(tag),
+                              selected: isSelected,
+                              onSelected: (selected) {
+                                setModalState(() {
+                                  selected
+                                      ? tempSelected.add(tag)
+                                      : tempSelected.remove(tag);
+                                });
+                              },
+                            );
+                          }).toList(),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const Divider(height: 1),
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: [
+                        ElevatedButton(
+                          onPressed: () {
+                            setState(() => _selectedTags = tempSelected);
+                            Navigator.pop(context);
+                          },
+                          child: const Text('Filter'),
+                        ),
+                        OutlinedButton(
+                          onPressed: () {
+                            setState(() => _selectedTags.clear());
+                            Navigator.pop(context);
+                          },
+                          child: const Text('Reset'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  List<DiscussionThread> get _filteredThreads {
+    if (_selectedTags.isEmpty) return _threads;
+    return _threads.where((thread) =>
+        thread.tags.any((tag) => _selectedTags.contains(tag))).toList();
   }
 
   Future<void> _loadThreads() async {
@@ -67,59 +179,77 @@ class _ForumPageState extends State<ForumPage> {
             )
           else if (_threads.isEmpty)
               const Center(child: Text('No discussions yet'))
-            else
-              RefreshIndicator(
-                onRefresh: _loadThreads,
-                  child: Scrollbar(
-                    thumbVisibility: true,
-                    child: ListView.builder(
-                      padding: const EdgeInsets.only(bottom: 100),
-                      itemCount: _threads.length,
-                      itemBuilder: (_, i) {
-                        final t = _threads[i];
-                        return Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                          child: ThreadTile(
-                            thread: t,
-                            onTap: () async {
-                              final result = await Navigator.push(
-                                ctx,
-                                MaterialPageRoute(
-                                  builder: (_) => ThreadDetailScreen(thread: t),
+            else ...[
+                Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: ElevatedButton.icon(
+                          onPressed: _showFilterModal,
+                          icon: const Icon(Icons.filter_list),
+                          label: const Text('Filter'),
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: RefreshIndicator(
+                        onRefresh: _loadThreads,
+                        child: Scrollbar(
+                          thumbVisibility: true,
+                          child: ListView.builder(
+                            padding: const EdgeInsets.only(bottom: 100),
+                            itemCount: _filteredThreads.length,
+                            itemBuilder: (_, i) {
+                              final t = _filteredThreads[i];
+                              return Padding(
+                                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                                child: ThreadTile(
+                                  thread: t,
+                                  onTap: () async {
+                                    final result = await Navigator.push(
+                                      ctx,
+                                      MaterialPageRoute(
+                                        builder: (_) => ThreadDetailScreen(thread: t),
+                                      ),
+                                    );
+                                    if (result is DiscussionThread) {
+                                      setState(() {
+                                        final index = _threads.indexWhere((thread) => thread.id == result.id);
+                                        if (index != -1) {
+                                          _threads[index] = result;
+                                        }
+                                      });
+                                    } else if (result == 'deleted') {
+                                      setState(() {
+                                        _threads.removeWhere((thread) => thread.id == t.id);
+                                      });
+                                    }
+                                  },
+                                  onEdit: (updatedThread) {
+                                    setState(() {
+                                      final index = _threads.indexWhere((th) => th.id == updatedThread.id);
+                                      if (index != -1) {
+                                        _threads[index] = updatedThread;
+                                      }
+                                    });
+                                  },
+                                  onDelete: () {
+                                    setState(() {
+                                      _threads.removeWhere((th) => th.id == t.id);
+                                    });
+                                  },
                                 ),
                               );
-                              if (result is DiscussionThread) {
-                                setState(() {
-                                  final index = _threads.indexWhere((thread) => thread.id == result.id);
-                                  if (index != -1) {
-                                    _threads[index] = result;
-                                  }
-                                });
-                              } else if (result == 'deleted') {
-                                setState(() {
-                                  _threads.removeWhere((thread) => thread.id == t.id);
-                                });
-                              }
-                            },
-                            onEdit: (updatedThread) {
-                              setState(() {
-                                final index = _threads.indexWhere((th) => th.id == updatedThread.id);
-                                if (index != -1) {
-                                  _threads[index] = updatedThread;
-                                }
-                              });
-                            },
-                            onDelete: () {
-                              setState(() {
-                                _threads.removeWhere((th) => th.id == t.id);
-                              });
                             },
                           ),
-                        );
-                      },
+                        ),
+                      ),
                     ),
-                  ),
-              ),
+                  ],
+                ),
+              ],
           // Always show FAB
           Positioned(
             bottom: 16,

--- a/apps/mobile/lib/features/forum/screens/thread_detail_screen.dart
+++ b/apps/mobile/lib/features/forum/screens/thread_detail_screen.dart
@@ -156,134 +156,137 @@ class _ThreadDetailScreenState extends State<ThreadDetailScreen> {
           Expanded(
             child: RefreshIndicator(
               onRefresh: _loadComments,
-              child: ListView.builder(
-                key: ValueKey(_comments.map((c) => c.id).join('-')), // Force rebuild
-                itemCount: _comments.length + 2,
-                itemBuilder: (ctx, i) {
-                  if (i == 0) {
-                    return Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Card(
-                        elevation: 2,
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                        child: Padding(
-                          padding: const EdgeInsets.all(16),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Row(
-                                children: [
-                                  CircleAvatar(
-                                    radius: 18,
-                                    child: Text(
-                                      _currentThread.creatorUsername.isNotEmpty
-                                          ? _currentThread.creatorUsername[0].toUpperCase()
-                                          : '?',
-                                    ),
-                                  ),
-                                  const SizedBox(width: 10),
-                                  Text(
-                                    _currentThread.creatorUsername,
-                                    style: Theme.of(context).textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w600),
-                                  ),
-                                ],
-                              ),
-                              const SizedBox(height: 12),
-                              Wrap(
-                                spacing: 6,
-                                children: _currentThread.tags.map((tag) => Chip(label: Text(tag))).toList(),
-                              ),
-                              const SizedBox(height: 12),
-                              Text(
-                                _currentThread.body,
-                                style: Theme.of(context).textTheme.bodyLarge,
-                              ),
-                              const SizedBox(height: 12),
-                              Wrap(
-                                spacing: 12,
-                                crossAxisAlignment: WrapCrossAlignment.center,
-                                children: [
-                                  Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      const Icon(Icons.calendar_today, size: 16),
-                                      const SizedBox(width: 4),
-                                      Text(
-                                        'Created: ${_currentThread.createdAt.toLocal().toString().split(".").first}',
-                                        style: Theme.of(context).textTheme.bodySmall,
+              child: Scrollbar(
+                thumbVisibility: true,
+                child: ListView.builder(
+                  key: ValueKey(_comments.map((c) => c.id).join('-')), // Force rebuild
+                  itemCount: _comments.length + 2,
+                  itemBuilder: (ctx, i) {
+                    if (i == 0) {
+                      return Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Card(
+                          elevation: 2,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                          child: Padding(
+                            padding: const EdgeInsets.all(16),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  children: [
+                                    CircleAvatar(
+                                      radius: 18,
+                                      child: Text(
+                                        _currentThread.creatorUsername.isNotEmpty
+                                            ? _currentThread.creatorUsername[0].toUpperCase()
+                                            : '?',
                                       ),
-                                    ],
-                                  ),
-                                  if (_currentThread.editedAt != null)
+                                    ),
+                                    const SizedBox(width: 10),
+                                    Text(
+                                      _currentThread.creatorUsername,
+                                      style: Theme.of(context).textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w600),
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: 12),
+                                Wrap(
+                                  spacing: 6,
+                                  children: _currentThread.tags.map((tag) => Chip(label: Text(tag))).toList(),
+                                ),
+                                const SizedBox(height: 12),
+                                Text(
+                                  _currentThread.body,
+                                  style: Theme.of(context).textTheme.bodyLarge,
+                                ),
+                                const SizedBox(height: 12),
+                                Wrap(
+                                  spacing: 12,
+                                  crossAxisAlignment: WrapCrossAlignment.center,
+                                  children: [
                                     Row(
                                       mainAxisSize: MainAxisSize.min,
                                       children: [
-                                        const Icon(Icons.edit, size: 16),
+                                        const Icon(Icons.calendar_today, size: 16),
                                         const SizedBox(width: 4),
                                         Text(
-                                          'Edited: ${_currentThread.editedAt!.toLocal().toString().split(".").first}',
+                                          'Created: ${_currentThread.createdAt.toLocal().toString().split(".").first}',
                                           style: Theme.of(context).textTheme.bodySmall,
                                         ),
                                       ],
                                     ),
-                                ],
-                              ),
-                            ],
+                                    if (_currentThread.editedAt != null)
+                                      Row(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          const Icon(Icons.edit, size: 16),
+                                          const SizedBox(width: 4),
+                                          Text(
+                                            'Edited: ${_currentThread.editedAt!.toLocal().toString().split(".").first}',
+                                            style: Theme.of(context).textTheme.bodySmall,
+                                          ),
+                                        ],
+                                      ),
+                                  ],
+                                ),
+                              ],
+                            ),
                           ),
                         ),
-                      ),
-                    );
-                  }
-                  if (i == 1) return const Divider();
+                      );
+                    }
+                    if (i == 1) return const Divider();
 
-                  final comment = _comments[i - 2];
-                  return Column(
-                    key: ValueKey("comment-block-${comment.id}"),
-                    children: [
-                      CommentTile(
-                        key: ValueKey("comment-${comment.id}"),
-                        comment: comment,
-                        onUpdate: (id, newBody) {
-                          setState(() {
-                            final index = _comments.indexWhere((c) => c.id == id);
-                            if (index != -1) {
-                              _comments[index] = Comment(
-                                id: id,
-                                body: newBody,
-                                author: _comments[index].author,
-                                reported: _comments[index].reported,
-                                createdAt: _comments[index].createdAt,
+                    final comment = _comments[i - 2];
+                    return Column(
+                      key: ValueKey("comment-block-${comment.id}"),
+                      children: [
+                        CommentTile(
+                          key: ValueKey("comment-${comment.id}"),
+                          comment: comment,
+                          onUpdate: (id, newBody) {
+                            setState(() {
+                              final index = _comments.indexWhere((c) => c.id == id);
+                              if (index != -1) {
+                                _comments[index] = Comment(
+                                  id: id,
+                                  body: newBody,
+                                  author: _comments[index].author,
+                                  reported: _comments[index].reported,
+                                  createdAt: _comments[index].createdAt,
+                                );
+                              }
+                            });
+                          },
+                          onDelete: (id) async {
+                            try {
+                              final success = await _api.deleteComment(id);
+                              if (success) {
+                                setState(() {
+                                  _comments.removeWhere((c) => c.id == id);
+                                });
+                              } else {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(content: Text("Failed to delete comment.", style: TextStyle(color: Colors.red))),
+                                );
+                              }
+                            } on SocketException {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text("Failed: Please check your connection and refresh the page.", style: TextStyle(color: Colors.red))),
                               );
-                            }
-                          });
-                        },
-                        onDelete: (id) async {
-                          try {
-                            final success = await _api.deleteComment(id);
-                            if (success) {
-                              setState(() {
-                                _comments.removeWhere((c) => c.id == id);
-                              });
-                            } else {
+                            } catch (e) {
                               ScaffoldMessenger.of(context).showSnackBar(
                                 const SnackBar(content: Text("Failed to delete comment.", style: TextStyle(color: Colors.red))),
                               );
                             }
-                          } on SocketException {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text("Failed: Please check your connection and refresh the page.", style: TextStyle(color: Colors.red))),
-                            );
-                          } catch (e) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text("Failed to delete comment.", style: TextStyle(color: Colors.red))),
-                            );
-                          }
-                        },
-                      ),
-                      const Divider(),
-                    ],
-                  );
-                },
+                          },
+                        ),
+                        const Divider(),
+                      ],
+                    );
+                  },
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## 🚀 Feature: Tag Recommendation Using External API + Tag Filtering Support

This PR implements the requested enhancements in **[Issue #164](https://github.com/bounswe/bounswe2025group4/issues/164)**, bringing smarter UX to the forum creation flow by using external api ([Datamuse API](https://www.datamuse.com/api/)) and better navigability through tag-based filtering.

---

## ✅ What’s Implemented

### 🔍 1. **Tag Recommendation with Datamuse API**
- Integrated [Datamuse API](https://www.datamuse.com/api/) to suggest relevant tags based on the thread **title**.
- A new service `TagRecommendationService` sends the title as a query (`ml=...`) and processes top 2 high-score suggestions.
- Suggestions are:
  - Filtered for non-empty, short-enough words.
  - Normalized to uppercase.
  - Displayed as selectable InputChips in the tag selection modal.

🔁 **UX Enhancements**:
- Users get meaningful tag suggestions with one click ("Suggest Tags").
- Suggestions are visually distinct (e.g., orange chips with lightbulb icons).

---

### 🏷️ 2. **Forum Tag Filtering**
- Added ability to filter forum threads by selecting one or more tags.
- Tags fetched from backend (`/tags`) and displayed in a filter modal.
- Filtering logic matches threads with any of the selected tags.
- A "Reset" option clears filters and reloads all threads.

---

## 🧪 Testing Done
- ✅ Tag recommendation tested with various title inputs.
- ✅ API error, empty title, and no-match scenarios handled with clear feedback.
- ✅ Forum list successfully filters based on tags.
- ✅ Full UI tested in CreateThreadScreen, ForumPage, and ThreadDetailScreen.

---


## 🎯 Linked Issue
Closes #164
Closes #84 