### PR TITLE
Feat/254 Add Dark Mode to the mobile app

### DIFF
--- a/apps/jobboard-mobile/lib/app.dart
+++ b/apps/jobboard-mobile/lib/app.dart
@@ -5,6 +5,7 @@ import 'generated/l10n/app_localizations.dart';
 import 'core/providers/auth_provider.dart';
 import 'core/providers/font_size_provider.dart';
 import 'core/providers/locale_provider.dart';
+import 'core/providers/theme_provider.dart';
 import 'features/auth/screens/welcome_screen.dart';
 import 'features/main_scaffold/main_scaffold.dart';
 
@@ -13,8 +14,8 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer2<FontSizeProvider, LocaleProvider>(
-      builder: (context, fontSizeProvider, localeProvider, child) {
+    return Consumer3<FontSizeProvider, LocaleProvider, ThemeProvider>(
+      builder: (context, fontSizeProvider, localeProvider, themeProvider, child) {
         return MaterialApp(
           title: 'EthicaJobs',
           
@@ -39,11 +40,38 @@ class MyApp extends StatelessWidget {
             // If not supported, return the first supported locale (English)
             return supportedLocales.first;
           },
-          
+
+          themeMode: themeProvider.themeMode,
           theme: ThemeData(
+            brightness: Brightness.light,
             primarySwatch: Colors.blue,
             visualDensity: VisualDensity.adaptivePlatformDensity,
             textTheme: ThemeData.light().textTheme.copyWith(
+              bodyLarge: TextStyle(
+                fontSize: fontSizeProvider.getScaledFontSize(16),
+              ),
+              bodyMedium: TextStyle(
+                fontSize: fontSizeProvider.getScaledFontSize(14),
+              ),
+              bodySmall: TextStyle(
+                fontSize: fontSizeProvider.getScaledFontSize(12),
+              ),
+              titleLarge: TextStyle(
+                fontSize: fontSizeProvider.getScaledFontSize(22),
+              ),
+              titleMedium: TextStyle(
+                fontSize: fontSizeProvider.getScaledFontSize(18),
+              ),
+              titleSmall: TextStyle(
+                fontSize: fontSizeProvider.getScaledFontSize(16),
+              ),
+            ),
+          ),
+          darkTheme: ThemeData(
+            brightness: Brightness.dark,
+            primarySwatch: Colors.blue,
+            visualDensity: VisualDensity.adaptivePlatformDensity,
+            textTheme: ThemeData.dark().textTheme.copyWith(
               bodyLarge: TextStyle(
                 fontSize: fontSizeProvider.getScaledFontSize(16),
               ),

--- a/apps/jobboard-mobile/lib/core/providers/theme_provider.dart
+++ b/apps/jobboard-mobile/lib/core/providers/theme_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class ThemeProvider extends ChangeNotifier {
+  ThemeMode _themeMode = ThemeMode.light; // Default to light mode
+
+  ThemeMode get themeMode => _themeMode;
+
+  bool get isDarkMode => _themeMode == ThemeMode.dark;
+
+  void toggleTheme(bool isOn) {
+    _themeMode = isOn ? ThemeMode.dark : ThemeMode.light;
+    notifyListeners();
+  }
+}

--- a/apps/jobboard-mobile/lib/features/auth/screens/mentorship_selection_screen.dart
+++ b/apps/jobboard-mobile/lib/features/auth/screens/mentorship_selection_screen.dart
@@ -273,7 +273,7 @@ class _MentorshipSelectionScreenState extends State<MentorshipSelectionScreen> {
                     style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.bold,
-                      color: isSelected ? Colors.blue : Colors.black,
+                      color: isSelected ? Colors.blue : Theme.of(context).colorScheme.onSurface,
                     ),
                   ),
                   const SizedBox(height: 4),

--- a/apps/jobboard-mobile/lib/features/auth/screens/user_type_screen.dart
+++ b/apps/jobboard-mobile/lib/features/auth/screens/user_type_screen.dart
@@ -146,7 +146,7 @@ class _UserTypeScreenState extends State<UserTypeScreen> {
                       fontSize: 18,
                       fontWeight:
                           isSelected ? FontWeight.bold : FontWeight.normal,
-                      color: isSelected ? Colors.blue : Colors.black,
+                      color: isSelected ? Colors.blue : Theme.of(context).colorScheme.onSurface,
                     ),
                   ),
                   const SizedBox(height: 4),

--- a/apps/jobboard-mobile/lib/features/auth/screens/welcome_screen.dart
+++ b/apps/jobboard-mobile/lib/features/auth/screens/welcome_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:mobile/features/auth/screens/user_type_screen.dart';
 import 'package:mobile/features/auth/screens/sign_in_screen.dart';
 import 'package:mobile/generated/l10n/app_localizations.dart';
+import 'package:mobile/core/providers/theme_provider.dart';
+import 'package:provider/provider.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'dart:async';
@@ -93,6 +95,11 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
+              const Positioned(
+                top: 16,
+                right: 24,
+                child: ThemeToggleSwitch(),
+              ),
               if (_isLoading)
                 const CircularProgressIndicator()
               else if (_hasError)
@@ -212,6 +219,39 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
           ),
         ),
       ),
+    );
+  }
+}
+
+
+class ThemeToggleSwitch extends StatelessWidget {
+  const ThemeToggleSwitch({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final themeProvider = Provider.of<ThemeProvider>(context);
+    final color = Theme.of(context).primaryColor;
+    final isDarkMode = themeProvider.isDarkMode;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          isDarkMode ? Icons.dark_mode : Icons.light_mode,
+          color: isDarkMode ? Colors.white : color,
+        ),
+        const SizedBox(width: 8),
+        Switch.adaptive(
+          value: isDarkMode,
+          onChanged: (value) {
+            Provider.of<ThemeProvider>(context, listen: false).toggleTheme(value);
+          },
+          activeColor: Colors.amber,
+          activeTrackColor: Colors.amber.withOpacity(0.5),
+          inactiveThumbColor: isDarkMode ? Colors.white : Colors.grey.shade400,
+          inactiveTrackColor: isDarkMode ? Colors.grey.shade700 : Colors.grey.shade300,
+        ),
+      ],
     );
   }
 }

--- a/apps/jobboard-mobile/lib/main.dart
+++ b/apps/jobboard-mobile/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'core/providers/auth_provider.dart'; // Adjust path
+import 'core/providers/theme_provider.dart';
 import 'core/providers/quote_provider.dart';
 import 'core/providers/profile_provider.dart';
 import 'core/providers/font_size_provider.dart';
@@ -18,6 +19,7 @@ void main() {
         ), // Add QuoteProvider
         ChangeNotifierProvider(create: (context) => FontSizeProvider()),
         ChangeNotifierProvider(create: (context) => LocaleProvider()),
+        ChangeNotifierProvider(create: (context) => ThemeProvider()),
         ProxyProvider<AuthProvider, ApiService>(
           update:
               (context, authProvider, _) =>


### PR DESCRIPTION
## Summary
Implemented a dark mode to the mobile app and a toggle switch to change between modes.

## Changes
- Added a new 'theme_provider.dart' file to have a change notifier in the theme. Modified the 'app.dart' and 'main.dart' as well.
- Fixed some hardcoded text colors on the signup page to adapt to mode changes better.
- Added a toggle switch to change from dark mode to light mode and vice versa on the 'welcome_screen.dart'. (The switch can be moved to the settings page when it can be done.)


## Acceptance Criteria
- [x] The user can select dark mode to change the UI
- [x] The toggle switch is usable and seen clearly to change modes
- [x] The UI is still clear in both modes

## Linked Issue
Closes [#254](https://github.com/bounswe/bounswe2025group4/issues/254)