### PR TITLE
fix: convert user role system from Set to single Role

### DIFF
--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/auth/dto/JwtResponse.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/auth/dto/JwtResponse.java
@@ -2,8 +2,6 @@ package org.bounswe.jobboardbackend.auth.dto;
 
 import lombok.Data;
 
-import java.util.List;
-
 @Data
 public class JwtResponse {
 
@@ -12,14 +10,14 @@ public class JwtResponse {
     private Long id;
     private String username;
     private String email;
-    private List<String> roles;
+    private String role;
 
-    public JwtResponse(String accessToken, Long id, String username, String email, List<String> roles) {
+    public JwtResponse(String accessToken, Long id, String username, String email, String role) {
         this.token = accessToken;
         this.id = id;
         this.username = username;
         this.email = email;
-        this.roles = roles;
+        this.role = role;
     }
 
 }

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/auth/dto/RegisterRequest.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/auth/dto/RegisterRequest.java
@@ -6,8 +6,6 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import java.util.Set;
-
 @Data
 @AllArgsConstructor
 public class RegisterRequest {
@@ -20,7 +18,8 @@ public class RegisterRequest {
     @Email
     private String email;
 
-    private Set<String> role;
+    @NotBlank
+    private String role;
 
     @NotBlank
     @Size(min = 6, max = 40)

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/auth/dto/UserResponse.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/auth/dto/UserResponse.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 
 @Builder
 @Data
@@ -16,6 +14,6 @@ public class UserResponse {
     private Long id;
     private String username;
     private String email;
-    private List<String> roles;
+    private String role;
 
 }

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/auth/model/User.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/auth/model/User.java
@@ -7,8 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.HashSet;
-import java.util.Set;
 
 
 @Builder
@@ -35,8 +33,9 @@ public class User {
     private String email;
     private String password;
 
-    @Builder.Default
-    private Set<Role> roles = new HashSet<>();
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
 
     @Column(nullable = false)
     @Builder.Default

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/auth/service/UserDetailsImpl.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/auth/service/UserDetailsImpl.java
@@ -11,7 +11,6 @@ import java.io.Serial;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Data
 public class UserDetailsImpl implements UserDetails {
@@ -39,9 +38,9 @@ public class UserDetailsImpl implements UserDetails {
     }
 
     public static UserDetailsImpl build(User user) {
-        List<GrantedAuthority> authorities = user.getRoles().stream()
-                .map(role -> new SimpleGrantedAuthority(role.name()))
-                .collect(Collectors.toList());
+        List<GrantedAuthority> authorities = List.of(
+                new SimpleGrantedAuthority(user.getRole().name())
+        );
 
         return new UserDetailsImpl(
                 user.getId(),

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/jobapplication/service/JobApplicationService.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/jobapplication/service/JobApplicationService.java
@@ -63,7 +63,7 @@ public class JobApplicationService {
         User jobSeeker = getCurrentUser();
 
         // Check if user has JOBSEEKER role
-        if (!jobSeeker.getRoles().contains(Role.ROLE_JOBSEEKER)) {
+        if (jobSeeker.getRole() != Role.ROLE_JOBSEEKER) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only users with JOBSEEKER role can apply for jobs");
         }
 

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/jobpost/service/JobPostService.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/jobpost/service/JobPostService.java
@@ -61,7 +61,7 @@ public class JobPostService {
     public JobPostResponse create(CreateJobPostRequest dto) {
         User employer = getCurrentUser();
 
-        if (!employer.getRoles().contains(Role.ROLE_EMPLOYER)) {
+        if (employer.getRole() != Role.ROLE_EMPLOYER) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only users with EMPLOYER role can post jobs.");
         }
 


### PR DESCRIPTION
## Fix: Refactor User Role System to Single Role

### Problem
- Users had `Set<Role>` but only needed one role
- Switch-case bug: missing `break` statements caused multiple roles to be assigned unintentionally
- No validation requiring role selection

### Changes
- Changed `User.role` from `Set<Role>` to single `Role` with `@Enumerated(EnumType.STRING)`
- Made role mandatory in registration with `@NotBlank`
- Fixed switch-case fall-through bug 
- Updated all DTOs: `JwtResponse`, `UserResponse`, `RegisterRequest`
- Updated role checks in `JobPostService` and `JobApplicationService`


### API Changes
**Before:** `{ "roles": ["ROLE_EMPLOYER"] }`  
**After:** `{ "role": "ROLE_EMPLOYER" }`
