### PR TITLE
fix: add server header strategy

### DIFF
--- a/apps/jobboard-backend/src/main/resources/application.yml
+++ b/apps/jobboard-backend/src/main/resources/application.yml
@@ -29,6 +29,7 @@ spring:
 
 server:
   port: 8080
+  forward-headers-strategy: framework
 
 app:
   env: ${APP_ENV}


### PR DESCRIPTION
the requests on swagger UI are being sent over http instead of https causing cors errors. this PR solves that