### PR TITLE
refactor: Use authStore for authentication state instead of localStorage

### DIFF
--- a/apps/jobboard-frontend/src/components/layout/Header.tsx
+++ b/apps/jobboard-frontend/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Menu } from 'lucide-react';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import {
   Sheet,
   SheetContent,
@@ -10,32 +10,16 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import { ThemeToggle } from '../ThemeToggle';
+import { useAuthStore } from '@/stores/authStore';
 
 export default function Header() {
   const navigate = useNavigate();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-
-  useEffect(() => {
-    // Check if user is logged in (token exists)
-    const checkAuth = () => {
-      const token = localStorage.getItem('token');
-      setIsLoggedIn(!!token);
-    };
-
-    checkAuth();
-
-    // Listen for auth changes
-    window.addEventListener('auth-change', checkAuth);
-    
-    return () => {
-      window.removeEventListener('auth-change', checkAuth);
-    };
-  }, []);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const logout = useAuthStore((state) => state.logout);
 
   const handleLogout = () => {
-    localStorage.removeItem('token');
-    window.dispatchEvent(new Event('auth-change'));
+    logout();
     navigate('/');
   };
 
@@ -65,7 +49,7 @@ export default function Header() {
           {/* Desktop Auth Buttons */}
           <div className="hidden md:flex items-center gap-2">
             <ThemeToggle />
-            {isLoggedIn ? (
+            {isAuthenticated ? (
               <Button variant="outline" onClick={handleLogout}>
                 Logout
               </Button>
@@ -113,7 +97,7 @@ export default function Header() {
               </nav>
 
               <div className="flex flex-col gap-2 p-2 border-t mt-4">
-                {isLoggedIn ? (
+                {isAuthenticated ? (
                   <Button variant="outline" onClick={() => {
                     handleLogout();
                     setIsMobileMenuOpen(false);

--- a/apps/jobboard-frontend/src/contexts/AuthContext.tsx
+++ b/apps/jobboard-frontend/src/contexts/AuthContext.tsx
@@ -46,10 +46,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const storeLogout = useAuthStore((state) => state.logout);
   const restoreSession = useAuthStore((state) => state.restoreSession);
 
-  // Restore session on mount
+  // Restore session on mount (only once)
   useEffect(() => {
     restoreSession();
-  }, [restoreSession]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Login function - wraps store login
   const login = useCallback(

--- a/apps/jobboard-frontend/src/pages/LoginPage.tsx
+++ b/apps/jobboard-frontend/src/pages/LoginPage.tsx
@@ -6,17 +6,16 @@ import { Button } from '../components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
 import axios from 'axios';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
+import { useAuthStore } from '../stores/authStore';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL?.endsWith('/api') 
   ? import.meta.env.VITE_API_URL 
   : (import.meta.env.VITE_API_URL || '') + '/api';
 
-console.log('LoginPage - VITE_API_URL:', import.meta.env.VITE_API_URL);
-console.log('LoginPage - API_BASE_URL:', API_BASE_URL);
-
 export default function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const login = useAuthStore((state) => state.login);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
@@ -56,10 +55,6 @@ export default function LoginPage() {
         password: data.password,
       });
 
-      console.log('Login response:', response);
-      console.log('Login response data:', response.data);
-      console.log('Token:', response.data.token);
-
       if (response.status === 200) {
         // Check if 2FA is required
         if (response.data.temporaryToken) {
@@ -71,11 +66,8 @@ export default function LoginPage() {
             },
           });
         } else if (response.data.token) {
-          // No 2FA - direct login
-          localStorage.setItem('token', response.data.token);
-          
-          // Dispatch custom event to update header
-          window.dispatchEvent(new Event('auth-change'));
+          // No 2FA - direct login using authStore
+          login(response.data);
           
           // Redirect to home
           navigate('/');

--- a/apps/jobboard-frontend/src/pages/VerifyOtpPage.tsx
+++ b/apps/jobboard-frontend/src/pages/VerifyOtpPage.tsx
@@ -6,17 +6,16 @@ import { Button } from '../components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
 import axios from 'axios';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuthStore } from '../stores/authStore';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL?.endsWith('/api') 
   ? import.meta.env.VITE_API_URL 
   : (import.meta.env.VITE_API_URL || '') + '/api';
 
-console.log('VerifyOtpPage - VITE_API_URL:', import.meta.env.VITE_API_URL);
-console.log('VerifyOtpPage - API_BASE_URL:', API_BASE_URL);
-
 export default function VerifyOtpPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const login = useAuthStore((state) => state.login);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -48,15 +47,9 @@ export default function VerifyOtpPage() {
         temporaryToken: temporaryToken,
       });
 
-      console.log('Verify OTP response:', response);
-      console.log('Verify OTP response data:', response.data);
-
       if (response.status === 200 && response.data.token) {
-        // Store token
-        localStorage.setItem('token', response.data.token);
-        
-        // Dispatch custom event to update header
-        window.dispatchEvent(new Event('auth-change'));
+        // Login using authStore
+        login(response.data);
         
         // Redirect to home
         navigate('/');


### PR DESCRIPTION
## Description
Refactors authentication to use authStore (Zustand) consistently instead of direct localStorage manipulation and custom events.

## Changes
- Use `authStore.login()` in LoginPage and VerifyOtpPage
- Use `authStore.logout()` in Header
- Remove manual localStorage token management
- Remove custom `auth-change` event dispatching
- Remove debug console.logs
