### PR TITLE
Refactor/387-workplace-endpoints

### DIFF
--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/dto/EmployerListItem.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/dto/EmployerListItem.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 public class EmployerListItem {
     private Long userId;
     private String username;
+    private String nameSurname;
     private String email;
     private String role;
     private Instant joinedAt;

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/dto/EmployerRequestResponse.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/dto/EmployerRequestResponse.java
@@ -13,6 +13,8 @@ public class EmployerRequestResponse {
     private Long id;
     private Long workplaceId;
     private Long createdByUserId;
+    private String username;
+    private String nameSurname;
     private String status; // EmployerRequestStatus
     private String note;
     private Instant createdAt;

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/dto/ReplyResponse.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/dto/ReplyResponse.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 public class ReplyResponse {
     private Long id;
     private Long reviewId;
+    private String workplaceName;
     private Long employerUserId;
     private String content;
     private Instant createdAt;

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/dto/ReportListItem.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/dto/ReportListItem.java
@@ -16,6 +16,7 @@ public class ReportListItem {
     private String reasonType; // enum name
     private String status;     // ReportStatus
     private Long createdByUserId;
+    private String username;
     private String adminNote;
     private Instant createdAt;
 }

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/dto/ReviewResponse.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/dto/ReviewResponse.java
@@ -13,7 +13,9 @@ import java.util.Map;
 public class ReviewResponse {
     private Long id;
     private Long workplaceId;
-    private Long userId; // TODO: anon dönerken frontend göstermeyebilir
+    private Long userId; // TODO: anon dönerken null dönebiliriz
+    private String username; // TODO: anon dönerken anonymousUser dönebiliriz
+    private String nameSurname; // TODO: anon dönerken null dönebiliriz
     private String title;
     private String content;
     private boolean anonymous;

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/service/EmployerService.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/service/EmployerService.java
@@ -9,6 +9,7 @@ import org.bounswe.jobboardbackend.workplace.repository.*;
 import org.bounswe.jobboardbackend.auth.model.User;
 import org.bounswe.jobboardbackend.auth.model.Role;
 import org.bounswe.jobboardbackend.auth.repository.UserRepository;
+import org.bounswe.jobboardbackend.profile.repository.ProfileRepository;
 import org.springframework.data.domain.*;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ public class EmployerService {
     private final EmployerWorkplaceRepository employerWorkplaceRepository;
     private final EmployerRequestRepository employerRequestRepository;
     private final UserRepository userRepository;
+    private final ProfileRepository profileRepository;
     private final WorkplaceService workplaceService;
 
     // === HELPERS ===
@@ -68,6 +70,9 @@ public class EmployerService {
                 .map(ew -> EmployerListItem.builder()
                         .userId(ew.getUser().getId())
                         .username(ew.getUser().getUsername())
+                        .nameSurname(profileRepository.findByUserId(ew.getUser().getId())
+                                .map(p -> p.getFirstName() + " " + p.getLastName())
+                                .orElse(""))
                         .email(ew.getUser().getEmail())
                         .role(ew.getRole() != null ? ew.getRole().name() : null)
                         .joinedAt(ew.getCreatedAt())
@@ -234,10 +239,15 @@ public class EmployerService {
 
     // === MAPPERS ===
     private EmployerRequestResponse toDto(EmployerRequest er) {
+        String nameSurname = profileRepository.findByUserId(er.getCreatedBy().getId())
+                .map(p -> p.getFirstName() + " " + p.getLastName())
+                .orElse("");
         return EmployerRequestResponse.builder()
                 .id(er.getId())
                 .workplaceId(er.getWorkplace().getId())
                 .createdByUserId(er.getCreatedBy() != null ? er.getCreatedBy().getId() : null)
+                .username(er.getCreatedBy() != null ? er.getCreatedBy().getUsername() : null)
+                .nameSurname(nameSurname)
                 .note(er.getNote())
                 .status(er.getStatus() != null ? er.getStatus().name() : null)
                 .createdAt(er.getCreatedAt())

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/service/ReplyService.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/service/ReplyService.java
@@ -53,6 +53,7 @@ public class ReplyService {
         return ReplyResponse.builder()
                 .id(rr.getId())
                 .reviewId(rr.getReview().getId())
+                .workplaceName(rr.getReview().getWorkplace().getCompanyName())
                 .employerUserId(rr.getEmployerUser() != null ? rr.getEmployerUser().getId() : null)
                 .content(rr.getContent())
                 .createdAt(rr.getCreatedAt())

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/service/WorkplaceService.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/workplace/service/WorkplaceService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.security.access.AccessDeniedException;
 import org.bounswe.jobboardbackend.auth.repository.UserRepository;
+import org.bounswe.jobboardbackend.profile.repository.ProfileRepository;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -36,6 +37,7 @@ public class WorkplaceService {
     private final ReviewRepository reviewRepository;
     private final ReviewPolicyRatingRepository reviewPolicyRatingRepository;
     private final UserRepository userRepository;
+    private final ProfileRepository profileRepository;
 
     // === GCS config ===
     @Value("${app.gcs.bucket:bounswe-jobboard}")
@@ -322,6 +324,9 @@ public class WorkplaceService {
                 .map(ew -> EmployerListItem.builder()
                         .userId(ew.getUser().getId())
                         .username(ew.getUser().getUsername())
+                        .nameSurname(profileRepository.findByUserId(ew.getUser().getId())
+                                .map(p -> p.getFirstName() + " " + p.getLastName())
+                                .orElse(""))
                         .email(ew.getUser().getEmail())
                         .role(ew.getRole() != null ? ew.getRole().name() : null)
                         .joinedAt(ew.getCreatedAt())


### PR DESCRIPTION
## Summary
This PR extends the response DTOs for **Review**, **Reply**, and **EmployerRequest** to include additional user-related fields and workplace information.

### Changes
- Added `username` and `nameSurname` fields to **ReviewResponse** and **EmployerRequestResponse**.
- Added `workplaceName` field to **ReplyResponse**.
- Updated related service and controller layers to populate these new fields.
- Ensured that if a user does not have a profile, `nameSurname` defaults to an empty string.

### Impact
These updates improve response clarity by providing essential user and workplace context directly in API responses, reducing the need for extra frontend queries.

### Related Issue
Closes #387 