### PR TITLE
feat/434 added public profile page

### DIFF
--- a/apps/jobboard-frontend/public/locales/ar/common.json
+++ b/apps/jobboard-frontend/public/locales/ar/common.json
@@ -368,6 +368,8 @@
       "openToOpportunities": "متاح لفرص جديدة",
       "currentRole": "{{position}} في {{company}}",
       "joined": "انضم في {{year}}",
+      "posts": "منشورات",
+      "badges": "شارات",
       "stats": {
         "posts": "منشورات",
         "badges": "شارات"
@@ -389,6 +391,7 @@
     "about": {
       "title": "نبذة",
       "addBio": "أضف سيرة ذاتية",
+      "noBio": "لا توجد سيرة ذاتية متوفرة",
       "modal": {
         "title": "تعديل النبذة",
         "bioLabel": "السيرة الذاتية",
@@ -399,6 +402,7 @@
     "experience": {
       "title": "الخبرات",
       "empty": "أضف خبرة",
+      "noExperience": "لا توجد خبرة عمل متوفرة",
       "modal": {
         "addTitle": "إضافة خبرة",
         "editTitle": "تعديل الخبرة",
@@ -432,6 +436,7 @@
     "education": {
       "title": "التعليم",
       "empty": "أضف تعليماً",
+      "noEducation": "لا توجد معلومات تعليمية متوفرة",
       "modal": {
         "addTitle": "إضافة تعليم",
         "editTitle": "تعديل التعليم",
@@ -469,6 +474,7 @@
     "skills": {
       "title": "المهارات",
       "empty": "أضف مهارات",
+      "noSkills": "لا توجد مهارات مدرجة",
       "modal": {
         "addTitle": "إضافة مهارة",
         "editTitle": "تعديل المهارة",
@@ -486,6 +492,7 @@
     "interests": {
       "title": "الاهتمامات",
       "empty": "أضف اهتمامات",
+      "noInterests": "لا توجد اهتمامات مدرجة",
       "modal": {
         "addTitle": "إضافة اهتمام",
         "editTitle": "تعديل الاهتمام",
@@ -722,7 +729,7 @@
     "findMentors": "البحث عن مرشدين",
     "started": "بدأ",
     "accepted": "مقبول",
-    "completed": "مكتمل",
+    "completedDate": "مكتمل",
     "duration": "المدة",
     "learningGoals": "أهداف التعلم",
     "openChat": "فتح المحادثة",
@@ -926,39 +933,6 @@
       "errorMessage": "فشل إرسال طلب الإرشاد. يرجى المحاولة مرة أخرى."
     }
   },
-  "myMentorships": {
-    "title": "إرشاداتي",
-    "subtitle": "تتبع طلبات الإرشاد والإرشادات النشطة",
-    "successMessage": "تم إرسال طلب الإرشاد بنجاح إلى {{mentorName}}!",
-    "active": "نشط",
-    "pending": "قيد الانتظار",
-    "completed": "مكتمل",
-    "rejected": "مرفوض",
-    "noActive": "لا توجد إرشادات نشطة",
-    "noActiveDesc": "ليس لديك أي إرشادات نشطة حتى الآن. ابحث عن مرشد للبدء!",
-    "noPending": "لا توجد طلبات قيد الانتظار",
-    "noPendingDesc": "ليس لديك أي طلبات إرشاد قيد الانتظار.",
-    "noCompleted": "لا توجد إرشادات مكتملة",
-    "noCompletedDesc": "لم تكمل أي إرشادات بعد.",
-    "noRejected": "لا توجد طلبات مرفوضة",
-    "noRejectedDesc": "ليس لديك أي طلبات إرشاد مرفوضة.",
-    "findMentors": "ابحث عن مرشدين",
-    "started": "بدأ",
-    "accepted": "مقبول",
-    "completedDate": "مكتمل",
-    "duration": "المدة",
-    "learningGoals": "أهداف التعلم",
-    "openChat": "فتح المحادثة",
-    "writeReview": "كتابة تقييم",
-    "waitingForResponse": "في انتظار الرد",
-    "viewDetails": "عرض التفاصيل",
-    "status": {
-      "active": "نشط",
-      "pending": "قيد الانتظار",
-      "completed": "مكتمل",
-      "rejected": "مرفوض"
-    }
-  },
   "reviews": {
     "workplaceReviews": "تقييمات مكان العمل",
     "writeReview": "اكتب تقييماً",
@@ -1066,5 +1040,8 @@
     "roleMentee": "مسترشد",
     "selectConversation": "اختر محادثة",
     "selectConversationDesc": "اختر محادثة من القائمة للبدء في الدردشة"
+  },
+  "public": {
+    "note": "هذا الملف الشخصي العام - إمكانيات التعديل غير متاحة"
   }
 }

--- a/apps/jobboard-frontend/public/locales/en/common.json
+++ b/apps/jobboard-frontend/public/locales/en/common.json
@@ -567,7 +567,6 @@
       "findMentors": "Find Mentors",
       "started": "Started",
       "accepted": "Accepted",
-      "completed": "Completed",
       "duration": "Duration",
       "learningGoals": "Learning Goals",
       "openChat": "Open Chat",
@@ -599,6 +598,8 @@
       "openToOpportunities": "Open to opportunities",
       "currentRole": "{{position}} at {{company}}",
       "joined": "Joined in {{year}}",
+      "posts": "posts",
+      "badges": "badges",
       "stats": {
         "posts": "Posts",
         "badges": "Badges"
@@ -620,6 +621,7 @@
     "about": {
       "title": "About",
       "addBio": "Add bio",
+      "noBio": "No bio available",
       "modal": {
         "title": "Edit About",
         "bioLabel": "Bio",
@@ -630,6 +632,7 @@
     "experience": {
       "title": "Experience",
       "empty": "Add experience",
+      "noExperience": "No work experience available",
       "modal": {
         "addTitle": "Add Experience",
         "editTitle": "Edit Experience",
@@ -663,6 +666,7 @@
     "education": {
       "title": "Education",
       "empty": "Add education",
+      "noEducation": "No education information available",
       "modal": {
         "addTitle": "Add Education",
         "editTitle": "Edit Education",
@@ -700,6 +704,7 @@
     "skills": {
       "title": "Skills",
       "empty": "Add skills",
+      "noSkills": "No skills listed",
       "modal": {
         "addTitle": "Add Skill",
         "editTitle": "Edit Skill",
@@ -717,6 +722,7 @@
     "interests": {
       "title": "Interests",
       "empty": "Add interests",
+      "noInterests": "No interests listed",
       "modal": {
         "addTitle": "Add Interest",
         "editTitle": "Edit Interest",
@@ -815,6 +821,9 @@
       "saveInterestSuccess": "Interest saved successfully.",
       "saveInterestError": "Failed to save interest.",
       "deleteAccountSuccess": "All profile data has been deleted."
+    },
+    "public": {
+      "note": "This is a public profile view. Skills and interests are not displayed for privacy."
     },
     "activity": {
       "items": [
@@ -951,7 +960,6 @@
     "atCompany": "at {{company}}",
     "applicantInfo": "Applicant Information",
     "status": "Status",
-    "applied": "Applied",
     "coverLetter": "Cover Letter",
     "specialNeeds": "Special Needs or Accommodations",
     "cv": "CV / Resume",

--- a/apps/jobboard-frontend/public/locales/tr/common.json
+++ b/apps/jobboard-frontend/public/locales/tr/common.json
@@ -551,7 +551,7 @@
       "findMentors": "Mentor Bul",
       "started": "Başlangıç",
       "accepted": "Kabul Edildi",
-      "completed": "Tamamlandı",
+      "completedDate": "Tamamlandı",
       "duration": "Süre",
       "learningGoals": "Öğrenme Hedefleri",
       "openChat": "Sohbeti Aç",
@@ -583,6 +583,8 @@
       "openToOpportunities": "Fırsatlara açık",
       "currentRole": "{{company}} bünyesinde {{position}}",
       "joined": "{{year}} yılında katıldı",
+      "posts": "gönderi",
+      "badges": "rozet",
       "stats": {
         "posts": "Gönderi",
         "badges": "Rozet"
@@ -604,6 +606,7 @@
     "about": {
       "title": "Hakkında",
       "addBio": "Biyografi ekle",
+      "noBio": "Biyografi mevcut değil",
       "modal": {
         "title": "Hakkında'yı Düzenle",
         "bioLabel": "Biyografi",
@@ -614,6 +617,7 @@
     "experience": {
       "title": "Deneyim",
       "empty": "Deneyim ekle",
+      "noExperience": "İş deneyimi mevcut değil",
       "modal": {
         "addTitle": "Deneyim Ekle",
         "editTitle": "Deneyimi Düzenle",
@@ -647,6 +651,7 @@
     "education": {
       "title": "Eğitim",
       "empty": "Eğitim ekle",
+      "noEducation": "Eğitim bilgisi mevcut değil",
       "modal": {
         "addTitle": "Eğitim Ekle",
         "editTitle": "Eğitimi Düzenle",
@@ -684,6 +689,7 @@
     "skills": {
       "title": "Yetenekler",
       "empty": "Yetenek ekle",
+      "noSkills": "Yetenek listesi mevcut değil",
       "modal": {
         "addTitle": "Yetenek Ekle",
         "editTitle": "Yetenek Düzenle",
@@ -701,6 +707,7 @@
     "interests": {
       "title": "İlgi Alanları",
       "empty": "İlgi alanı ekle",
+      "noInterests": "İlgi alanı listesi mevcut değil",
       "modal": {
         "addTitle": "İlgi Alanı Ekle",
         "editTitle": "İlgi Alanını Düzenle",
@@ -799,6 +806,9 @@
       "saveInterestSuccess": "İlgi alanı başarıyla kaydedildi.",
       "saveInterestError": "İlgi alanı kaydedilemedi.",
       "deleteAccountSuccess": "Tüm profil verileri silindi."
+    },
+    "public": {
+      "note": "Bu halka açık bir profil görünümüdür. Gizlilik nedeniyle yetenekler ve ilgi alanları gösterilmez."
     },
     "activity": {
       "items": [
@@ -938,7 +948,7 @@
     "findMentors": "Mentor Bul",
     "started": "Başlangıç",
     "accepted": "Kabul Edildi",
-    "completed": "Tamamlandı",
+    "completedDate": "Tamamlandı",
     "duration": "Süre",
     "learningGoals": "Öğrenme Hedefleri",
     "openChat": "Sohbeti Aç",
@@ -1075,39 +1085,6 @@
     "submitting": "Yayınlanıyor...",
     "submitError": "İş ilanı oluşturulamadı. Lütfen tekrar deneyin.",
     "submitSuccess": "İş ilanı başarıyla oluşturuldu!"
-  },
-  "myMentorships": {
-    "title": "Mentorluk İlişkilerim",
-    "subtitle": "Mentorluk taleplerinizi ve aktif mentorluk ilişkilerinizi takip edin",
-    "successMessage": "{{mentorName}} için mentorluk talebi başarıyla gönderildi!",
-    "active": "Aktif",
-    "pending": "Beklemede",
-    "completed": "Tamamlandı",
-    "rejected": "Reddedildi",
-    "noActive": "Aktif Mentorluk Yok",
-    "noActiveDesc": "Henüz aktif mentorluk ilişkiniz bulunmuyor. Başlamak için bir mentor bulun!",
-    "noPending": "Bekleyen Talep Yok",
-    "noPendingDesc": "Bekleyen mentorluk talebiniz bulunmuyor.",
-    "noCompleted": "Tamamlanan Mentorluk Yok",
-    "noCompletedDesc": "Henüz tamamlanmış mentorluk ilişkiniz bulunmuyor.",
-    "noRejected": "Reddedilen Talep Yok",
-    "noRejectedDesc": "Reddedilmiş mentorluk talebiniz bulunmuyor.",
-    "findMentors": "Mentor Bul",
-    "started": "Başlangıç",
-    "accepted": "Kabul Edildi",
-    "completedDate": "Tamamlandı",
-    "duration": "Süre",
-    "learningGoals": "Öğrenme Hedefleri",
-    "openChat": "Sohbeti Aç",
-    "writeReview": "Değerlendirme Yaz",
-    "waitingForResponse": "Yanıt Bekleniyor",
-    "viewDetails": "Detayları Görüntüle",
-    "status": {
-      "active": "Aktif",
-      "pending": "Beklemede",
-      "completed": "Tamamlandı",
-      "rejected": "Reddedildi"
-    }
   },
   "reviews": {
     "workplaceReviews": "İşyeri Değerlendirmeleri",

--- a/apps/jobboard-frontend/src/components/profile/AboutSection.tsx
+++ b/apps/jobboard-frontend/src/components/profile/AboutSection.tsx
@@ -5,27 +5,34 @@ import { useTranslation } from 'react-i18next';
 interface AboutSectionProps {
   bio?: string;
   onEdit?: () => void;
+  isPublicView?: boolean;
 }
 
-export function AboutSection({ bio, onEdit }: AboutSectionProps) {
+export function AboutSection({ bio, onEdit, isPublicView = false }: AboutSectionProps) {
   const { t } = useTranslation('common');
 
   return (
     <section className="space-y-2 group">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-semibold">{t('profile.about.title')}</h2>
-        <Button
-          size="icon-sm"
-          variant="ghost"
-          className="opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={onEdit}
-          aria-label={t('profile.about.modal.title')}
-        >
-          <Pencil className="h-4 w-4" />
-        </Button>
+        {!isPublicView && (
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            className="opacity-0 group-hover:opacity-100 transition-opacity"
+            onClick={onEdit}
+            aria-label={t('profile.about.modal.title')}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+        )}
       </div>
       {bio ? (
         <p className="text-muted-foreground leading-relaxed">{bio}</p>
+      ) : isPublicView ? (
+        <p className="text-muted-foreground leading-relaxed">
+          {t('profile.about.noBio')}
+        </p>
       ) : (
         <div
           className="border-2 border-dashed rounded-lg p-6 flex items-center justify-center gap-2 text-muted-foreground hover:border-primary/50 hover:text-primary cursor-pointer transition-colors"

--- a/apps/jobboard-frontend/src/components/profile/EducationItem.tsx
+++ b/apps/jobboard-frontend/src/components/profile/EducationItem.tsx
@@ -16,9 +16,10 @@ interface EducationItemProps {
   education: Education;
   onEdit?: (id: number) => void;
   onDelete?: (id: number) => void;
+  isPublicView?: boolean;
 }
 
-export function EducationItem({ education, onEdit, onDelete }: EducationItemProps) {
+export function EducationItem({ education, onEdit, onDelete, isPublicView = false }: EducationItemProps) {
   const { t, i18n } = useTranslation('common');
   const locale = (i18n.resolvedLanguage ?? i18n.language) || 'en';
   const yearFormatter = new Intl.DateTimeFormat(locale, { year: 'numeric' });
@@ -29,23 +30,25 @@ export function EducationItem({ education, onEdit, onDelete }: EducationItemProp
 
   return (
     <div className="bg-muted/30 rounded-lg p-4 group relative">
-      <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity flex gap-1">
-        <Button
-          size="icon-sm"
-          variant="ghost"
-          onClick={() => onEdit?.(education.id)}
-        >
-          <Pencil className="h-3 w-3" />
-        </Button>
-        <Button
-          size="icon-sm"
-          variant="ghost"
-          onClick={() => onDelete?.(education.id)}
-          className="text-destructive hover:text-destructive"
-        >
-          <Trash2 className="h-3 w-3" />
-        </Button>
-      </div>
+      {!isPublicView && (
+        <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity flex gap-1">
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            onClick={() => onEdit?.(education.id)}
+          >
+            <Pencil className="h-3 w-3" />
+          </Button>
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            onClick={() => onDelete?.(education.id)}
+            className="text-destructive hover:text-destructive"
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      )}
       <div className="flex gap-3">
         <div className="mt-1">
           <GraduationCap className="h-5 w-5 text-muted-foreground" />

--- a/apps/jobboard-frontend/src/components/profile/EducationSection.tsx
+++ b/apps/jobboard-frontend/src/components/profile/EducationSection.tsx
@@ -18,6 +18,7 @@ interface EducationSectionProps {
   onAdd?: () => void;
   onEdit?: (id: number) => void;
   onDelete?: (id: number) => void;
+  isPublicView?: boolean;
 }
 
 export function EducationSection({
@@ -25,6 +26,7 @@ export function EducationSection({
   onAdd,
   onEdit,
   onDelete,
+  isPublicView = false,
 }: EducationSectionProps) {
   const { t } = useTranslation('common');
 
@@ -32,17 +34,29 @@ export function EducationSection({
     <section className="space-y-3">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-semibold">{t('profile.education.title')}</h2>
-        <Button size="sm" variant="ghost" className="gap-2" onClick={onAdd}>
-          <Plus className="h-4 w-4" />
-          {t('profile.actions.add')}
-        </Button>
+        {!isPublicView && (
+          <Button size="sm" variant="ghost" className="gap-2" onClick={onAdd}>
+            <Plus className="h-4 w-4" />
+            {t('profile.actions.add')}
+          </Button>
+        )}
       </div>
       {educations.length > 0 ? (
         <div className="space-y-3">
           {educations.map((edu) => (
-            <EducationItem key={edu.id} education={edu} onEdit={onEdit} onDelete={onDelete} />
+            <EducationItem 
+              key={edu.id} 
+              education={edu} 
+              onEdit={isPublicView ? undefined : onEdit} 
+              onDelete={isPublicView ? undefined : onDelete}
+              isPublicView={isPublicView}
+            />
           ))}
         </div>
+      ) : isPublicView ? (
+        <p className="text-muted-foreground text-sm">
+          {t('profile.education.noEducation')}
+        </p>
       ) : (
         <div
           className="border-2 border-dashed rounded-lg p-6 flex items-center justify-center gap-2 text-muted-foreground hover:border-primary/50 hover:text-primary cursor-pointer transition-colors"

--- a/apps/jobboard-frontend/src/components/profile/ExperienceItem.tsx
+++ b/apps/jobboard-frontend/src/components/profile/ExperienceItem.tsx
@@ -15,9 +15,10 @@ interface ExperienceItemProps {
   experience: Experience;
   onEdit?: (id: number) => void;
   onDelete?: (id: number) => void;
+  isPublicView?: boolean;
 }
 
-export function ExperienceItem({ experience, onEdit, onDelete }: ExperienceItemProps) {
+export function ExperienceItem({ experience, onEdit, onDelete, isPublicView = false }: ExperienceItemProps) {
   const { t, i18n } = useTranslation('common');
   const locale = (i18n.resolvedLanguage ?? i18n.language) || 'en';
   const dateFormatter = new Intl.DateTimeFormat(locale, {
@@ -31,23 +32,25 @@ export function ExperienceItem({ experience, onEdit, onDelete }: ExperienceItemP
 
   return (
     <div className="bg-muted/30 rounded-lg p-4 group relative">
-      <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity flex gap-1">
-        <Button
-          size="icon-sm"
-          variant="ghost"
-          onClick={() => onEdit?.(experience.id)}
-        >
-          <Pencil className="h-3 w-3" />
-        </Button>
-        <Button
-          size="icon-sm"
-          variant="ghost"
-          onClick={() => onDelete?.(experience.id)}
-          className="text-destructive hover:text-destructive"
-        >
-          <Trash2 className="h-3 w-3" />
-        </Button>
-      </div>
+      {!isPublicView && (
+        <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity flex gap-1">
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            onClick={() => onEdit?.(experience.id)}
+          >
+            <Pencil className="h-3 w-3" />
+          </Button>
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            onClick={() => onDelete?.(experience.id)}
+            className="text-destructive hover:text-destructive"
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      )}
       <div className="flex gap-3">
         <div className="mt-1">
           <Briefcase className="h-5 w-5 text-muted-foreground" />

--- a/apps/jobboard-frontend/src/components/profile/ExperienceSection.tsx
+++ b/apps/jobboard-frontend/src/components/profile/ExperienceSection.tsx
@@ -17,6 +17,7 @@ interface ExperienceSectionProps {
   onAdd?: () => void;
   onEdit?: (id: number) => void;
   onDelete?: (id: number) => void;
+  isPublicView?: boolean;
 }
 
 export function ExperienceSection({
@@ -24,6 +25,7 @@ export function ExperienceSection({
   onAdd,
   onEdit,
   onDelete,
+  isPublicView = false,
 }: ExperienceSectionProps) {
   const { t } = useTranslation('common');
 
@@ -31,17 +33,29 @@ export function ExperienceSection({
     <section className="space-y-3">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-semibold">{t('profile.experience.title')}</h2>
-        <Button size="sm" variant="ghost" className="gap-2" onClick={onAdd}>
-          <Plus className="h-4 w-4" />
-          {t('profile.actions.add')}
-        </Button>
+        {!isPublicView && (
+          <Button size="sm" variant="ghost" className="gap-2" onClick={onAdd}>
+            <Plus className="h-4 w-4" />
+            {t('profile.actions.add')}
+          </Button>
+        )}
       </div>
       {experiences.length > 0 ? (
         <div className="space-y-3">
           {experiences.map((exp) => (
-            <ExperienceItem key={exp.id} experience={exp} onEdit={onEdit} onDelete={onDelete} />
+            <ExperienceItem 
+              key={exp.id} 
+              experience={exp} 
+              onEdit={isPublicView ? undefined : onEdit} 
+              onDelete={isPublicView ? undefined : onDelete} 
+              isPublicView={isPublicView}
+            />
           ))}
         </div>
+      ) : isPublicView ? (
+        <p className="text-muted-foreground text-sm">
+          {t('profile.experience.noExperience')}
+        </p>
       ) : (
         <div
           className="border-2 border-dashed rounded-lg p-6 flex items-center justify-center gap-2 text-muted-foreground hover:border-primary/50 hover:text-primary cursor-pointer transition-colors"

--- a/apps/jobboard-frontend/src/components/profile/InterestsSection.tsx
+++ b/apps/jobboard-frontend/src/components/profile/InterestsSection.tsx
@@ -11,12 +11,14 @@ interface InterestsSectionProps {
   interests: Interest[];
   onAdd?: () => void;
   onEdit?: (id: number) => void;
+  isPublicView?: boolean;
 }
 
 export function InterestsSection({
   interests,
   onAdd,
   onEdit,
+  isPublicView = false,
 }: InterestsSectionProps) {
   const { t } = useTranslation('common');
 
@@ -24,15 +26,17 @@ export function InterestsSection({
     <section className="space-y-3 group">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-semibold">{t('profile.interests.title')}</h2>
-        <Button
-          size="sm"
-          variant="ghost"
-          className="gap-2 opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={onAdd}
-        >
-          <Plus className="h-4 w-4" />
-          {t('profile.actions.add')}
-        </Button>
+        {!isPublicView && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="gap-2 opacity-0 group-hover:opacity-100 transition-opacity"
+            onClick={onAdd}
+          >
+            <Plus className="h-4 w-4" />
+            {t('profile.actions.add')}
+          </Button>
+        )}
       </div>
       {interests.length > 0 ? (
         <div className="flex flex-wrap gap-2">
@@ -42,17 +46,23 @@ export function InterestsSection({
               className="bg-muted text-foreground px-3 py-1.5 rounded-full text-sm group/interest relative border"
             >
               {interest.name}
-              <Button
-                size="icon-sm"
-                variant="ghost"
-                className="absolute -top-1 -right-1 h-5 w-5 rounded-full opacity-0 group-hover/interest:opacity-100 transition-opacity bg-muted hover:bg-muted/80"
-                onClick={() => onEdit?.(interest.id)}
-              >
-                <Pencil className="h-2.5 w-2.5" />
-              </Button>
+              {!isPublicView && (
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  className="absolute -top-1 -right-1 h-5 w-5 rounded-full opacity-0 group-hover/interest:opacity-100 transition-opacity bg-muted hover:bg-muted/80"
+                  onClick={() => onEdit?.(interest.id)}
+                >
+                  <Pencil className="h-2.5 w-2.5" />
+                </Button>
+              )}
             </div>
           ))}
         </div>
+      ) : isPublicView ? (
+        <p className="text-muted-foreground text-sm">
+          {t('profile.interests.noInterests')}
+        </p>
       ) : (
         <div
           className="border-2 border-dashed rounded-lg p-6 flex items-center justify-center gap-2 text-muted-foreground hover:border-primary/50 hover:text-primary cursor-pointer transition-colors"

--- a/apps/jobboard-frontend/src/components/profile/SkillsSection.tsx
+++ b/apps/jobboard-frontend/src/components/profile/SkillsSection.tsx
@@ -12,24 +12,27 @@ interface SkillsSectionProps {
   skills: Skill[];
   onAdd?: () => void;
   onEdit?: (id: number) => void;
+  isPublicView?: boolean;
 }
 
-export function SkillsSection({ skills, onAdd, onEdit }: SkillsSectionProps) {
+export function SkillsSection({ skills, onAdd, onEdit, isPublicView = false }: SkillsSectionProps) {
   const { t } = useTranslation('common');
 
   return (
     <section className="space-y-3 group">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-semibold">{t('profile.skills.title')}</h2>
-        <Button
-          size="sm"
-          variant="ghost"
-          className="gap-2 opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={onAdd}
-        >
-          <Plus className="h-4 w-4" />
-          {t('profile.actions.add')}
-        </Button>
+        {!isPublicView && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="gap-2 opacity-0 group-hover:opacity-100 transition-opacity"
+            onClick={onAdd}
+          >
+            <Plus className="h-4 w-4" />
+            {t('profile.actions.add')}
+          </Button>
+        )}
       </div>
       {skills.length > 0 ? (
         <div className="flex flex-wrap gap-2">
@@ -39,17 +42,23 @@ export function SkillsSection({ skills, onAdd, onEdit }: SkillsSectionProps) {
               className="bg-muted text-foreground px-3 py-1.5 rounded-full text-sm group/skill relative border"
             >
               {skill.name}
-              <Button
-                size="icon-sm"
-                variant="ghost"
-                className="absolute -top-1 -right-1 h-5 w-5 rounded-full opacity-0 group-hover/skill:opacity-100 transition-opacity bg-muted hover:bg-muted/80"
-                onClick={() => onEdit?.(skill.id)}
-              >
-                <Pencil className="h-2.5 w-2.5" />
-              </Button>
+              {!isPublicView && (
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  className="absolute -top-1 -right-1 h-5 w-5 rounded-full opacity-0 group-hover/skill:opacity-100 transition-opacity bg-muted hover:bg-muted/80"
+                  onClick={() => onEdit?.(skill.id)}
+                >
+                  <Pencil className="h-2.5 w-2.5" />
+                </Button>
+              )}
             </div>
           ))}
         </div>
+      ) : isPublicView ? (
+        <p className="text-muted-foreground text-sm">
+          {t('profile.skills.noSkills')}
+        </p>
       ) : (
         <div
           className="border-2 border-dashed rounded-lg p-6 flex items-center justify-center gap-2 text-muted-foreground hover:border-primary/50 hover:text-primary cursor-pointer transition-colors"

--- a/apps/jobboard-frontend/src/pages/PublicProfilePage.tsx
+++ b/apps/jobboard-frontend/src/pages/PublicProfilePage.tsx
@@ -1,0 +1,219 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { AboutSection } from '@/components/profile/AboutSection';
+import { ExperienceSection } from '@/components/profile/ExperienceSection';
+import { EducationSection } from '@/components/profile/EducationSection';
+import { ActivityTab } from '@/components/profile/ActivityTab';
+import { PostsTab } from '@/components/profile/PostsTab';
+import type { PublicProfile, Activity, Post } from '@/types/profile.types';
+import { profileService } from '@/services/profile.service';
+import CenteredLoader from '@/components/CenteredLoader';
+
+export default function PublicProfilePage() {
+  const { userId } = useParams<{ userId: string }>();
+  const [activeTab, setActiveTab] = useState<'about' | 'activity' | 'posts'>('about');
+  const [profile, setProfile] = useState<PublicProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { t } = useTranslation('common');
+
+  // Mock data for activity and posts (since these are not part of the public profile)
+  const mockActivity: Activity[] = useMemo(() => {
+    const items = t('profile.activity.items', {
+      returnObjects: true,
+    }) as Array<Pick<Activity, 'type' | 'text' | 'date'>>;
+
+    return items.map((item, index) => ({
+      id: index + 1,
+      ...item,
+    }));
+  }, [t]);
+
+  const mockPosts: Post[] = useMemo(() => {
+    const items = t('profile.posts.items', {
+      returnObjects: true,
+    }) as Array<Pick<Post, 'title' | 'date'>>;
+
+    const defaults = [
+      { replies: 12, likes: 45 },
+      { replies: 8, likes: 32 },
+      { replies: 24, likes: 67 },
+    ];
+
+    return items.map((item, index) => ({
+      id: index + 1,
+      title: item.title,
+      date: item.date,
+      replies: defaults[index]?.replies ?? 0,
+      likes: defaults[index]?.likes ?? 0,
+    }));
+  }, [t]);
+
+  useEffect(() => {
+    const loadPublicProfile = async () => {
+      if (!userId) return;
+      
+      try {
+        setLoading(true);
+        setError(null);
+        const profileData = await profileService.getPublicProfile(parseInt(userId));
+        setProfile(profileData);
+      } catch (err) {
+        console.error('Failed to load public profile:', err);
+        setError(t('profile.page.loadErrorTitle'));
+        toast.error(t('profile.page.loadErrorTitle'));
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadPublicProfile();
+  }, [userId, t]);
+
+  if (loading) {
+    return <CenteredLoader />;
+  }
+
+  if (error || !profile) {
+    return (
+      <div className="max-w-5xl mx-auto space-y-6 py-16">
+        <div className="bg-muted rounded-lg p-6 text-center">
+          <p className="font-medium">
+            {error || t('profile.page.emptyTitle')}
+          </p>
+          <p className="text-sm text-muted-foreground mt-2">
+            {t('profile.page.emptyDescription')}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const joinYear = new Date().getFullYear(); // Since public profile doesn't have createdAt, use current year
+  const currentJob = profile.experiences.find((exp) => !exp.endDate);
+  const currentRoleLabel = currentJob
+    ? t('profile.header.currentRole', {
+        position: currentJob.position,
+        company: currentJob.company,
+      })
+    : t('profile.header.openToOpportunities');
+  const joinedLabel = t('profile.header.joined', { year: joinYear });
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6 py-16">
+      <div className="bg-card rounded-lg border shadow-sm p-6">
+        {/* Public Profile Header */}
+        <div className="flex items-start gap-6 pb-6">
+          <div className="relative">
+            <Avatar className="h-32 w-32">
+              <AvatarImage
+                src={profile.imageUrl}
+                alt={`${profile.firstName} ${profile.lastName}`}
+              />
+              <AvatarFallback className="text-3xl">
+                {profile.firstName.charAt(0)}
+                {profile.lastName.charAt(0)}
+              </AvatarFallback>
+            </Avatar>
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <h1 className="text-3xl font-bold text-foreground mb-2">
+              {profile.firstName} {profile.lastName}
+            </h1>
+
+            <p className="text-muted-foreground mb-3">{currentRoleLabel}</p>
+
+            <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground mb-4">
+              <span>{joinedLabel}</span>
+              <span>•</span>
+              <span>42 {t('profile.header.posts')}</span>
+              <span>•</span>
+              <span>5 {t('profile.header.badges')}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Navigation */}
+        <div className="border-b mb-6">
+          <div className="flex gap-8">
+            <button
+              onClick={() => setActiveTab('about')}
+              className={`pb-3 border-b-2 transition-colors ${
+                activeTab === 'about'
+                  ? 'border-green-600 text-green-600 font-medium'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {t('profile.tabs.about')}
+            </button>
+            <button
+              onClick={() => setActiveTab('activity')}
+              className={`pb-3 border-b-2 transition-colors ${
+                activeTab === 'activity'
+                  ? 'border-green-600 text-green-600 font-medium'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {t('profile.tabs.activity')}
+            </button>
+            <button
+              onClick={() => setActiveTab('posts')}
+              className={`pb-3 border-b-2 transition-colors ${
+                activeTab === 'posts'
+                  ? 'border-green-600 text-green-600 font-medium'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {t('profile.tabs.posts')}
+            </button>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+        {activeTab === 'about' && (
+          <div className="grid md:grid-cols-3 gap-6">
+            <div className="md:col-span-2 space-y-6">
+              {/* About Section - Read Only */}
+              <AboutSection bio={profile.bio} isPublicView={true} />
+
+              {/* Experience Section - Read Only */}
+              <ExperienceSection
+                experiences={profile.experiences.sort((a, b) => {
+                  if (!a.endDate && b.endDate) return -1;
+                  if (a.endDate && !b.endDate) return 1;
+                  if (!a.endDate && !b.endDate) {
+                    return new Date(b.startDate).getTime() - new Date(a.startDate).getTime();
+                  }
+                  const endDateA = a.endDate ? new Date(a.endDate) : new Date();
+                  const endDateB = b.endDate ? new Date(b.endDate) : new Date();
+                  return endDateB.getTime() - endDateA.getTime();
+                })}
+                isPublicView={true}
+              />
+
+              {/* Education Section - Read Only */}
+              <EducationSection
+                educations={profile.educations}
+                isPublicView={true}
+              />
+            </div>
+
+            <div className="space-y-6">
+              {/* Public profiles don't include skills and interests */}
+              <div className="text-muted-foreground text-sm">
+                {t('profile.public.note')}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'activity' && <ActivityTab activities={mockActivity} />}
+        {activeTab === 'posts' && <PostsTab posts={mockPosts} />}
+      </div>
+    </div>
+  );
+}

--- a/apps/jobboard-frontend/src/router.tsx
+++ b/apps/jobboard-frontend/src/router.tsx
@@ -31,6 +31,7 @@ import MentorProfilePage from './pages/MentorProfilePage';
 import MentorshipRequestPage from './pages/MentorshipRequestPage';
 import MyMentorshipsPage from './pages/MyMentorshipsPage';
 import ChatPage from './pages/ChatPage';
+import PublicProfilePage from './pages/PublicProfilePage';
 
 const router = createBrowserRouter([
   {
@@ -210,7 +211,7 @@ const router = createBrowserRouter([
       {
         path: 'profile/:userId',
         element: (
-            <ProfilePage />
+            <PublicProfilePage />
         ),
       },
     ],

--- a/apps/jobboard-frontend/src/services/profile.service.ts
+++ b/apps/jobboard-frontend/src/services/profile.service.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@/lib/api-client';
-import type { Profile } from '@/types/profile.types';
+import type { Profile, PublicProfile } from '@/types/profile.types';
 
 /**
  * Profile API Service
@@ -48,7 +48,7 @@ export const profileService = {
    * Get public profile by user ID
    * GET /profile/{userId}
    */
-  getPublicProfile: async (userId: number): Promise<Profile> => {
+  getPublicProfile: async (userId: number): Promise<PublicProfile> => {
     const response = await apiClient.get(`/profile/${userId}`);
     return response.data;
   },

--- a/apps/jobboard-frontend/src/types/profile.types.ts
+++ b/apps/jobboard-frontend/src/types/profile.types.ts
@@ -53,6 +53,17 @@ export interface Profile {
   updatedAt: string;
 }
 
+export interface PublicProfile {
+  userId: number;
+  firstName: string;
+  lastName: string;
+  bio?: string;
+  imageUrl?: string;
+  educations: Education[];
+  experiences: Experience[];
+  badges?: Badge[];
+}
+
 export interface Activity {
   id: number;
   type: 'application' | 'forum' | 'comment' | 'like';


### PR DESCRIPTION
## Added public profile functionality that allows users to view other users' profiles at /profile/:userId route.

## What's New
- New Route: /profile/:userId displays public profiles in read-only mode
- Public Profile Page: Created PublicProfilePage.tsx component for viewing other users
- Consistent UI: Uses existing profile components with isPublicView prop for read-only mode

Closes: #434 