### PR TITLE
fix: removed mr.status = 'ACCEPTED' filter.

### DIFF
--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/mentorship/repository/MentorshipRequestRepository.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/mentorship/repository/MentorshipRequestRepository.java
@@ -25,7 +25,7 @@ public interface MentorshipRequestRepository extends JpaRepository<MentorshipReq
             "JOIN mr.mentor m " +
             "LEFT JOIN ResumeReview rr ON rr.mentorshipRequest.id = mr.id " +
             "LEFT JOIN Conversation c ON c.resumeReview.id = rr.id " +
-            "WHERE mr.requester.id = :menteeId AND mr.status = 'ACCEPTED' " +
+            "WHERE mr.requester.id = :menteeId " +
             "ORDER BY mr.createdAt DESC")
     List<MentorshipDetailsDTO> findAllMentorshipDetailsByMenteeId(@Param("menteeId") Long menteeId);
 


### PR DESCRIPTION
This PR removes the `mr.status = 'ACCEPTED'` filter from the merge-request query.
The previous logic restricted results to only accepted mentorship requests(MRs), which prevented consumers of this query from seeing MRs in other relevant states.

### **Why This Change Was Needed**

* Some features require visibility into all MR statuses (e.g., pending, rejected, ...).
* The hardcoded filter caused incomplete or misleading data.
* Removing the filter aligns the query with the broader use-case for downstream logic and UI components.

### **What Changed**

* Removed the `mr.status = 'ACCEPTED'` condition from the query builder.
* Verified that sorting, and related joins still behave correctly with a wider result set.

Closes #445 
