### PR TITLE
added theme to toast notifications

### DIFF
--- a/apps/jobboard-frontend/src/modules/shared/layouts/RootLayout.tsx
+++ b/apps/jobboard-frontend/src/modules/shared/layouts/RootLayout.tsx
@@ -4,9 +4,12 @@ import { ToastContainer } from 'react-toastify';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
 import CenteredLoader from '../components/common/CenteredLoader';
+import { useTheme } from '../providers/ThemeProvider';
 import 'react-toastify/dist/ReactToastify.css';
 
 export default function RootLayout() {
+  const { theme } = useTheme();
+
   return (
     <div className="flex flex-col min-h-screen">
       <Header />
@@ -16,7 +19,7 @@ export default function RootLayout() {
         </Suspense>
       </main>
       <Footer />
-      <ToastContainer position="bottom-right" />
+      <ToastContainer position="bottom-right" theme={theme} />
     </div>
   );
 }


### PR DESCRIPTION
Toast notifications currently do not adapt correctly to the global dark-mode theme. Colors, contrast ratios, and background/foreground combinations are inconsistent with the rest of the UI, causing poor readability and violating the platform’s accessibility requirements. I polished the toast UI tokens so they behave consistently in both light and dark themes.

Closes: #489 