### PR TITLE
feat(dashboard): implement real forum statistics

### DIFF
--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/dashboard/dto/DashboardStatsResponse.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/dashboard/dto/DashboardStatsResponse.java
@@ -13,7 +13,10 @@ public class DashboardStatsResponse {
     private long totalEmployers;
     private long totalJobSeekers;
 
-    private long totalForumPosts;      // mock for now
+    // forum related stats
+    private long totalForumPosts;
+    private long totalForumComments;
+    private long newForumPostsThisWeek;
 
     // job post  related stats
     private long totalJobPosts;

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/dashboard/service/CommunityDashboardService.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/dashboard/service/CommunityDashboardService.java
@@ -13,6 +13,8 @@ import org.bounswe.jobboardbackend.mentorship.repository.MentorProfileRepository
 import org.bounswe.jobboardbackend.mentorship.repository.MentorReviewRepository;
 import org.bounswe.jobboardbackend.mentorship.repository.MentorshipRequestRepository;
 import org.bounswe.jobboardbackend.mentorship.repository.ResumeReviewRepository;
+import org.bounswe.jobboardbackend.forum.repository.ForumPostRepository;
+import org.bounswe.jobboardbackend.forum.repository.ForumCommentRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -29,6 +31,8 @@ public class CommunityDashboardService {
     private final MentorshipRequestRepository mentorshipRequestRepository;
     private final MentorReviewRepository mentorReviewRepository;
     private final ResumeReviewRepository resumeReviewRepository;
+    private final ForumPostRepository forumPostRepository;
+    private final ForumCommentRepository forumCommentRepository;
 
     private DashboardStatsResponse cachedStats = new DashboardStatsResponse();
 
@@ -67,8 +71,11 @@ public class CommunityDashboardService {
         long totalMentorReviews = mentorReviewRepository.count();
         long totalResumeReviews = resumeReviewRepository.count();
 
-        // mock for now
-        long forumPosts = 0;
+        // 5. Forum Stats
+        long forumPosts = forumPostRepository.count();
+        long forumComments = forumCommentRepository.count();
+        long newForumPostsThisWeek = forumPostRepository.countByCreatedAtAfter(
+                java.time.Instant.now().minus(java.time.Duration.ofDays(7)));
 
 
         // update the cached stats
@@ -78,6 +85,8 @@ public class CommunityDashboardService {
                 .totalJobSeekers(totalJobSeekers)
                 .totalJobPosts(totalJobPosts)
                 .totalForumPosts(forumPosts)
+                .totalForumComments(forumComments)
+                .newForumPostsThisWeek(newForumPostsThisWeek)
                 .remoteJobsCount(remoteJobs)
                 .inclusiveJobsCount(inclusiveJobs)
                 .newJobsThisWeekCount(newJobs)

--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/forum/repository/ForumPostRepository.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/forum/repository/ForumPostRepository.java
@@ -12,4 +12,10 @@ public interface ForumPostRepository extends JpaRepository<ForumPost, Long> {
      * Used for badge criteria checking.
      */
     long countByAuthorId(Long authorId);
+
+    /**
+     * Count posts created after a given date.
+     * Used for dashboard statistics (e.g., posts this week).
+     */
+    long countByCreatedAtAfter(java.time.Instant date);
 }


### PR DESCRIPTION
## Summary
This PR implements real forum statistics in the community dashboard, replacing the previously mocked data.

### Changes
- **ForumPostRepository**: Added `countByCreatedAtAfter(Instant date)` method for counting recent posts
- **DashboardStatsResponse**: Added new fields:
  - `totalForumPosts` - total number of forum posts
  - `totalForumComments` - total number of comments (engagement metric)
  - `newForumPostsThisWeek` - posts created in the last 7 days
- **CommunityDashboardService**: 
  - Injected `ForumPostRepository` and `ForumCommentRepository`
  - Replaced `long forumPosts = 0` mock with actual database queries
  - Added forum stats calculation in `refreshStats()` method



