### PR TITLE
Fix/526 Make Community Dashboard Publicly Accessible

### DIFF
--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/dashboard/controller/CommunityDashboardController.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/dashboard/controller/CommunityDashboardController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/public/dashboard")
 @RequiredArgsConstructor
-@PreAuthorize("isAuthenticated()")
 @Tag(name = "Community Dashboard", description = "Public API for community statistics")
 public class CommunityDashboardController {
 


### PR DESCRIPTION
# PR: Enable public access to community dashboard

### Description
This PR updates the community dashboard API to allow public access. Previously, the endpoint required authentication, which prevented the landing page from displaying community statistics to visitors.

### Changes
- Removed the authentication requirement for dashboard statistics.
- Guests can now retrieve community stats without a token.

### Related Issue
Closes #526 