### PR TITLE
refactor(auth): removed admin role from registration flow.

### DIFF
--- a/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/auth/service/AuthService.java
+++ b/apps/jobboard-backend/src/main/java/org/bounswe/jobboardbackend/auth/service/AuthService.java
@@ -157,7 +157,7 @@ public class AuthService {
         String strRole = registerRequest.getRole();
 
         Role role = switch (strRole) {
-            case "ROLE_ADMIN" -> Role.ROLE_ADMIN; // TODO: Disabled for security
+//            case "ROLE_ADMIN" -> Role.ROLE_ADMIN; // Disabled for security
             case "ROLE_EMPLOYER" -> Role.ROLE_EMPLOYER;
             case "ROLE_JOBSEEKER" -> Role.ROLE_JOBSEEKER;
             default -> throw new HandleException(ErrorCode.ROLE_INVALID, "User has no role assigned");


### PR DESCRIPTION
This PR refactors the authentication registration flow to remove assignment of the `admin` role during user registration. Role elevation is no longer possible at signup.

**What changed**

* Removed `admin` role handling from the registration logic
* Cleaned up related conditionals and validations in the auth flow

**Why**

* Prevents accidental or unauthorized privilege escalation
* Aligns registration with principle of least privilege

**Impact / Notes**

* No change to existing users or roles
* Admin roles must now be assigned through approved post-registration mechanisms (e.g., internal tooling or migrations)

**Testing**

* Confirmed admin role cannot be set via registration payload

---

Closes #271 
